### PR TITLE
Add clusters

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,3 +28,58 @@ repos:
           - --hook-config=--path-to-file=README.md
           - --hook-config=--add-to-exiting-file=true
           - --hook-config=--create-file-if-not-exist=false
+
+      - id: infracost_breakdown
+        args:
+          - --args=--sync-usage-file
+          - --args=--usage-file=global/infra/infracost/sandbox.yml
+          - --args=--path=global/infra
+          - --args=--terraform-var-file=tfvars/sandbox.tfvars
+      - id: infracost_breakdown
+        args:
+          - --args=--sync-usage-file
+          - --args=--usage-file=global/infra/infracost/non-production.yml
+          - --args=--path=global/infra
+          - --args=--terraform-var-file=tfvars/non-production.tfvars
+      - id: infracost_breakdown
+        args:
+          - --args=--sync-usage-file
+          - --args=--usage-file=global/infra/infracost/production.yml
+          - --args=--path=global/infra
+          - --args=--terraform-var-file=tfvars/production.tfvars
+      - id: infracost_breakdown
+        args:
+          - --args=--sync-usage-file
+          - --args=--usage-file=regional/infra/infracost/us-east1-sandbox.yml
+          - --args=--path=regional/infra
+          - --args=--terraform-var-file=tfvars/us-east1-sandbox.tfvars
+      - id: infracost_breakdown
+        args:
+          - --args=--sync-usage-file
+          - --args=--usage-file=regional/infra/infracost/us-east1-non-production.yml
+          - --args=--path=regional/infra
+          - --args=--terraform-var-file=tfvars/us-east1-non-production.tfvars
+      - id: infracost_breakdown
+        args:
+          - --args=--sync-usage-file
+          - --args=--usage-file=regional/infra/infracost/us-east1-production.yml
+          - --args=--path=regional/infra
+          - --args=--terraform-var-file=tfvars/us-east1-production.tfvars
+      - id: infracost_breakdown
+        args:
+          - --args=--sync-usage-file
+          - --args=--usage-file=regional/infra/infracost/us-east4-sandbox.yml
+          - --args=--path=regional/infra
+          - --args=--terraform-var-file=tfvars/us-east4-sandbox.tfvars
+      - id: infracost_breakdown
+        args:
+          - --args=--sync-usage-file
+          - --args=--usage-file=regional/infra/infracost/us-east4-non-production.yml
+          - --args=--path=regional/infra
+          - --args=--terraform-var-file=tfvars/us-east4-non-production.tfvars
+      - id: infracost_breakdown
+        args:
+          - --args=--sync-usage-file
+          - --args=--usage-file=regional/infra/infracost/us-east4-production.yml
+          - --args=--path=regional/infra
+          - --args=--terraform-var-file=tfvars/us-east4-production.tfvars

--- a/global/infra/README.md
+++ b/global/infra/README.md
@@ -35,4 +35,5 @@ No resources.
 | Name | Description |
 |------|-------------|
 | <a name="output_project_id"></a> [project\_id](#output\_project\_id) | The project ID |
+| <a name="output_project_number"></a> [project\_number](#output\_project\_number) | The project number |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/global/infra/outputs.tf
+++ b/global/infra/outputs.tf
@@ -5,3 +5,8 @@ output "project_id" {
   description = "The project ID"
   value       = module.project.project_id
 }
+
+output "project_number" {
+  description = "The project number"
+  value       = module.project.project_number
+}

--- a/regional/infra/.terraform.lock.hcl
+++ b/regional/infra/.terraform.lock.hcl
@@ -19,3 +19,41 @@ provider "registry.terraform.io/hashicorp/google" {
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/google-beta" {
+  version = "5.7.0"
+  hashes = [
+    "h1:6c1adMvZpeIv2oqXT0hoTCUO8LSq0UxWGJnPey56VKg=",
+    "zh:1720258635c34406db44e3d08df9cc02e6897f804d6d558e1c73772324df7b30",
+    "zh:1a385e9b3d7cda4d76b242f78086f33600c566386fde97d625f3bd39e1dcb1ff",
+    "zh:26e01a0059c3d9954d0af22ccc05bb21a5b8af7f91a790311cf8ba13e10a5646",
+    "zh:2acdab4240714cc31407324773280eeeb8ec9ab420404a3f3b8c0f25d73a5e00",
+    "zh:4836143995c83c925b040c8bc7d3958fa6743c2179a098e783bf919e17db16ab",
+    "zh:4ca384ea0153ba101af3ca97276f59e76586f935c99b444bd360a4009756af2d",
+    "zh:54cc3398e8c336bd3f836954f87d3a7ae8fc4bced070baac66a244af656163d4",
+    "zh:a3e5d9eacc27047ea0c3c00753da3966516dfc982dee180a3a5f4a405689447e",
+    "zh:cc2052e93d0b52151a2374aa49e56de823ff11dce0570fa7c4bbbcf89467670f",
+    "zh:d8dc64ade395715dbb41753bda72b1bce6348cd2011f95b1cea1b2c675770c58",
+    "zh:da1fe36816881dac4acd7ab37291365c4b92584b8689c7c745c7a5b6800049c0",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.5.1"
+  hashes = [
+    "h1:VSnd9ZIPyfKHOObuQCaKfnjIHRtR7qTw19Rz8tJxm+k=",
+    "zh:04e3fbd610cb52c1017d282531364b9c53ef72b6bc533acb2a90671957324a64",
+    "zh:119197103301ebaf7efb91df8f0b6e0dd31e6ff943d231af35ee1831c599188d",
+    "zh:4d2b219d09abf3b1bb4df93d399ed156cadd61f44ad3baf5cf2954df2fba0831",
+    "zh:6130bdde527587bbe2dcaa7150363e96dbc5250ea20154176d82bc69df5d4ce3",
+    "zh:6cc326cd4000f724d3086ee05587e7710f032f94fc9af35e96a386a1c6f2214f",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:b6d88e1d28cf2dfa24e9fdcc3efc77adcdc1c3c3b5c7ce503a423efbdd6de57b",
+    "zh:ba74c592622ecbcef9dc2a4d81ed321c4e44cddf7da799faa324da9bf52a22b2",
+    "zh:c7c5cde98fe4ef1143bd1b3ec5dc04baf0d4cc3ca2c5c7d40d17c0e9b2076865",
+    "zh:dac4bad52c940cd0dfc27893507c1e92393846b024c5a9db159a93c534a3da03",
+    "zh:de8febe2a2acd9ac454b844a4106ed295ae9520ef54dc8ed2faf29f12716b602",
+    "zh:eab0d0495e7e711cca367f7d4df6e322e6c562fc52151ec931176115b83ed014",
+  ]
+}

--- a/regional/infra/README.md
+++ b/regional/infra/README.md
@@ -13,7 +13,9 @@ No requirements.
 
 ## Modules
 
-No modules.
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_kubernetes"></a> [kubernetes](#module\_kubernetes) | github.com/osinfra-io/terraform-google-kubernetes-engine//regional | v0.1.0 |
 
 ## Resources
 
@@ -26,6 +28,8 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_environment"></a> [environment](#input\_environment) | The environment for example: `sandbox`, `non-production`, `production` | `string` | `"sandbox"` | no |
+| <a name="input_host_project_id"></a> [host\_project\_id](#input\_host\_project\_id) | Host project for the shared VPC | `string` | n/a | yes |
+| <a name="input_master_ipv4_cidr_block"></a> [master\_ipv4\_cidr\_block](#input\_master\_ipv4\_cidr\_block) | The IP range in CIDR notation to use for the hosted master network | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | The region to deploy the resources to | `string` | n/a | yes |
 | <a name="input_remote_bucket"></a> [remote\_bucket](#input\_remote\_bucket) | The remote bucket the `terraform_remote_state` data source retrieves the state from | `string` | n/a | yes |
 

--- a/regional/infra/README.md
+++ b/regional/infra/README.md
@@ -27,6 +27,7 @@ No requirements.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_enable_cluster"></a> [enable\_cluster](#input\_enable\_cluster) | Enable the creation of the GKE cluster | `bool` | `false` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | The environment for example: `sandbox`, `non-production`, `production` | `string` | `"sandbox"` | no |
 | <a name="input_host_project_id"></a> [host\_project\_id](#input\_host\_project\_id) | Host project for the shared VPC | `string` | n/a | yes |
 | <a name="input_master_ipv4_cidr_block"></a> [master\_ipv4\_cidr\_block](#input\_master\_ipv4\_cidr\_block) | The IP range in CIDR notation to use for the hosted master network | `string` | n/a | yes |

--- a/regional/infra/infracost/us-east1-non-production.yml
+++ b/regional/infra/infracost/us-east1-non-production.yml
@@ -3,33 +3,5 @@
 # `infracost breakdown --usage-file infracost-usage.yml [other flags]`
 # See https://infracost.io/usage-file/ for docs
 version: 0.1
-resource_type_default_usage:
-  ##
-  ## The following usage values apply to each resource of the given type, which is useful when you want to define defaults.
-  ## All values are commented-out, you can uncomment resource types and customize as needed.
-  ##
-  google_container_cluster:
-    autopilot_vcpu_count: 0.0 # Number of vCPUs used by Autopilot pods. Only relevant for Autopilot mode.
-    autopilot_memory_gb: 0.0 # Total memory used by Autopilot pods. Only relevant for Autopilot mode.
-    autopilot_ephemeral_storage_gb: 0.0 # Total ephemeral storage used by Autopilot pods. Only relevant for Autopilot mode.
-    # nodes: 0 # Node count per zone for the default node pool. Only relevant for Standard mode.
-    # node_pool[0]:
-      # nodes: 0 # Node count per zone for the first node pool. Only relevant for Standard mode.
-  google_kms_crypto_key:
-    key_versions: 0 # Number of key versions.
-    monthly_key_operations: 0 # Monthly number of key operations.
-# resource_usage:
-  ##
-  ## The following usage values apply to individual resources and override any value defined in the resource_type_default_usage section.
-  ## All values are commented-out, you can uncomment resources and customize as needed.
-  ##
-  # module.kubernetes.google_container_cluster.this:
-    # autopilot_vcpu_count: 0.0 # Number of vCPUs used by Autopilot pods. Only relevant for Autopilot mode.
-    # autopilot_memory_gb: 0.0 # Total memory used by Autopilot pods. Only relevant for Autopilot mode.
-    # autopilot_ephemeral_storage_gb: 0.0 # Total ephemeral storage used by Autopilot pods. Only relevant for Autopilot mode.
-    # nodes: 0 # Node count per zone for the default node pool. Only relevant for Standard mode.
-    # node_pool[0]:
-      # nodes: 0 # Node count per zone for the first node pool. Only relevant for Standard mode.
-  # module.kubernetes.google_kms_crypto_key.cluster_database_encryption:
-    # key_versions: 0 # Number of key versions.
-    # monthly_key_operations: 0 # Monthly number of key operations.
+# resource_type_default_usage: {}
+# resource_usage: {}

--- a/regional/infra/infracost/us-east1-non-production.yml
+++ b/regional/infra/infracost/us-east1-non-production.yml
@@ -4,3 +4,32 @@
 # See https://infracost.io/usage-file/ for docs
 version: 0.1
 resource_type_default_usage:
+  ##
+  ## The following usage values apply to each resource of the given type, which is useful when you want to define defaults.
+  ## All values are commented-out, you can uncomment resource types and customize as needed.
+  ##
+  google_container_cluster:
+    autopilot_vcpu_count: 0.0 # Number of vCPUs used by Autopilot pods. Only relevant for Autopilot mode.
+    autopilot_memory_gb: 0.0 # Total memory used by Autopilot pods. Only relevant for Autopilot mode.
+    autopilot_ephemeral_storage_gb: 0.0 # Total ephemeral storage used by Autopilot pods. Only relevant for Autopilot mode.
+    # nodes: 0 # Node count per zone for the default node pool. Only relevant for Standard mode.
+    # node_pool[0]:
+      # nodes: 0 # Node count per zone for the first node pool. Only relevant for Standard mode.
+  google_kms_crypto_key:
+    key_versions: 0 # Number of key versions.
+    monthly_key_operations: 0 # Monthly number of key operations.
+# resource_usage:
+  ##
+  ## The following usage values apply to individual resources and override any value defined in the resource_type_default_usage section.
+  ## All values are commented-out, you can uncomment resources and customize as needed.
+  ##
+  # module.kubernetes.google_container_cluster.this:
+    # autopilot_vcpu_count: 0.0 # Number of vCPUs used by Autopilot pods. Only relevant for Autopilot mode.
+    # autopilot_memory_gb: 0.0 # Total memory used by Autopilot pods. Only relevant for Autopilot mode.
+    # autopilot_ephemeral_storage_gb: 0.0 # Total ephemeral storage used by Autopilot pods. Only relevant for Autopilot mode.
+    # nodes: 0 # Node count per zone for the default node pool. Only relevant for Standard mode.
+    # node_pool[0]:
+      # nodes: 0 # Node count per zone for the first node pool. Only relevant for Standard mode.
+  # module.kubernetes.google_kms_crypto_key.cluster_database_encryption:
+    # key_versions: 0 # Number of key versions.
+    # monthly_key_operations: 0 # Monthly number of key operations.

--- a/regional/infra/infracost/us-east1-production.yml
+++ b/regional/infra/infracost/us-east1-production.yml
@@ -3,33 +3,5 @@
 # `infracost breakdown --usage-file infracost-usage.yml [other flags]`
 # See https://infracost.io/usage-file/ for docs
 version: 0.1
-resource_type_default_usage:
-  ##
-  ## The following usage values apply to each resource of the given type, which is useful when you want to define defaults.
-  ## All values are commented-out, you can uncomment resource types and customize as needed.
-  ##
-  google_container_cluster:
-    autopilot_vcpu_count: 0.0 # Number of vCPUs used by Autopilot pods. Only relevant for Autopilot mode.
-    autopilot_memory_gb: 0.0 # Total memory used by Autopilot pods. Only relevant for Autopilot mode.
-    autopilot_ephemeral_storage_gb: 0.0 # Total ephemeral storage used by Autopilot pods. Only relevant for Autopilot mode.
-    # nodes: 0 # Node count per zone for the default node pool. Only relevant for Standard mode.
-    # node_pool[0]:
-      # nodes: 0 # Node count per zone for the first node pool. Only relevant for Standard mode.
-  google_kms_crypto_key:
-    key_versions: 0 # Number of key versions.
-    monthly_key_operations: 0 # Monthly number of key operations.
-# resource_usage:
-  ##
-  ## The following usage values apply to individual resources and override any value defined in the resource_type_default_usage section.
-  ## All values are commented-out, you can uncomment resources and customize as needed.
-  ##
-  # module.kubernetes.google_container_cluster.this:
-    # autopilot_vcpu_count: 0.0 # Number of vCPUs used by Autopilot pods. Only relevant for Autopilot mode.
-    # autopilot_memory_gb: 0.0 # Total memory used by Autopilot pods. Only relevant for Autopilot mode.
-    # autopilot_ephemeral_storage_gb: 0.0 # Total ephemeral storage used by Autopilot pods. Only relevant for Autopilot mode.
-    # nodes: 0 # Node count per zone for the default node pool. Only relevant for Standard mode.
-    # node_pool[0]:
-      # nodes: 0 # Node count per zone for the first node pool. Only relevant for Standard mode.
-  # module.kubernetes.google_kms_crypto_key.cluster_database_encryption:
-    # key_versions: 0 # Number of key versions.
-    # monthly_key_operations: 0 # Monthly number of key operations.
+# resource_type_default_usage: {}
+# resource_usage: {}

--- a/regional/infra/infracost/us-east1-production.yml
+++ b/regional/infra/infracost/us-east1-production.yml
@@ -4,3 +4,32 @@
 # See https://infracost.io/usage-file/ for docs
 version: 0.1
 resource_type_default_usage:
+  ##
+  ## The following usage values apply to each resource of the given type, which is useful when you want to define defaults.
+  ## All values are commented-out, you can uncomment resource types and customize as needed.
+  ##
+  google_container_cluster:
+    autopilot_vcpu_count: 0.0 # Number of vCPUs used by Autopilot pods. Only relevant for Autopilot mode.
+    autopilot_memory_gb: 0.0 # Total memory used by Autopilot pods. Only relevant for Autopilot mode.
+    autopilot_ephemeral_storage_gb: 0.0 # Total ephemeral storage used by Autopilot pods. Only relevant for Autopilot mode.
+    # nodes: 0 # Node count per zone for the default node pool. Only relevant for Standard mode.
+    # node_pool[0]:
+      # nodes: 0 # Node count per zone for the first node pool. Only relevant for Standard mode.
+  google_kms_crypto_key:
+    key_versions: 0 # Number of key versions.
+    monthly_key_operations: 0 # Monthly number of key operations.
+# resource_usage:
+  ##
+  ## The following usage values apply to individual resources and override any value defined in the resource_type_default_usage section.
+  ## All values are commented-out, you can uncomment resources and customize as needed.
+  ##
+  # module.kubernetes.google_container_cluster.this:
+    # autopilot_vcpu_count: 0.0 # Number of vCPUs used by Autopilot pods. Only relevant for Autopilot mode.
+    # autopilot_memory_gb: 0.0 # Total memory used by Autopilot pods. Only relevant for Autopilot mode.
+    # autopilot_ephemeral_storage_gb: 0.0 # Total ephemeral storage used by Autopilot pods. Only relevant for Autopilot mode.
+    # nodes: 0 # Node count per zone for the default node pool. Only relevant for Standard mode.
+    # node_pool[0]:
+      # nodes: 0 # Node count per zone for the first node pool. Only relevant for Standard mode.
+  # module.kubernetes.google_kms_crypto_key.cluster_database_encryption:
+    # key_versions: 0 # Number of key versions.
+    # monthly_key_operations: 0 # Monthly number of key operations.

--- a/regional/infra/infracost/us-east1-sandbox.yml
+++ b/regional/infra/infracost/us-east1-sandbox.yml
@@ -3,33 +3,5 @@
 # `infracost breakdown --usage-file infracost-usage.yml [other flags]`
 # See https://infracost.io/usage-file/ for docs
 version: 0.1
-resource_type_default_usage:
-  ##
-  ## The following usage values apply to each resource of the given type, which is useful when you want to define defaults.
-  ## All values are commented-out, you can uncomment resource types and customize as needed.
-  ##
-  google_container_cluster:
-    autopilot_vcpu_count: 0.0 # Number of vCPUs used by Autopilot pods. Only relevant for Autopilot mode.
-    autopilot_memory_gb: 0.0 # Total memory used by Autopilot pods. Only relevant for Autopilot mode.
-    autopilot_ephemeral_storage_gb: 0.0 # Total ephemeral storage used by Autopilot pods. Only relevant for Autopilot mode.
-    # nodes: 0 # Node count per zone for the default node pool. Only relevant for Standard mode.
-    # node_pool[0]:
-      # nodes: 0 # Node count per zone for the first node pool. Only relevant for Standard mode.
-  google_kms_crypto_key:
-    key_versions: 0 # Number of key versions.
-    monthly_key_operations: 0 # Monthly number of key operations.
-# resource_usage:
-  ##
-  ## The following usage values apply to individual resources and override any value defined in the resource_type_default_usage section.
-  ## All values are commented-out, you can uncomment resources and customize as needed.
-  ##
-  # module.kubernetes.google_container_cluster.this:
-    # autopilot_vcpu_count: 0.0 # Number of vCPUs used by Autopilot pods. Only relevant for Autopilot mode.
-    # autopilot_memory_gb: 0.0 # Total memory used by Autopilot pods. Only relevant for Autopilot mode.
-    # autopilot_ephemeral_storage_gb: 0.0 # Total ephemeral storage used by Autopilot pods. Only relevant for Autopilot mode.
-    # nodes: 0 # Node count per zone for the default node pool. Only relevant for Standard mode.
-    # node_pool[0]:
-      # nodes: 0 # Node count per zone for the first node pool. Only relevant for Standard mode.
-  # module.kubernetes.google_kms_crypto_key.cluster_database_encryption:
-    # key_versions: 0 # Number of key versions.
-    # monthly_key_operations: 0 # Monthly number of key operations.
+# resource_type_default_usage: {}
+# resource_usage: {}

--- a/regional/infra/infracost/us-east1-sandbox.yml
+++ b/regional/infra/infracost/us-east1-sandbox.yml
@@ -4,3 +4,32 @@
 # See https://infracost.io/usage-file/ for docs
 version: 0.1
 resource_type_default_usage:
+  ##
+  ## The following usage values apply to each resource of the given type, which is useful when you want to define defaults.
+  ## All values are commented-out, you can uncomment resource types and customize as needed.
+  ##
+  google_container_cluster:
+    autopilot_vcpu_count: 0.0 # Number of vCPUs used by Autopilot pods. Only relevant for Autopilot mode.
+    autopilot_memory_gb: 0.0 # Total memory used by Autopilot pods. Only relevant for Autopilot mode.
+    autopilot_ephemeral_storage_gb: 0.0 # Total ephemeral storage used by Autopilot pods. Only relevant for Autopilot mode.
+    # nodes: 0 # Node count per zone for the default node pool. Only relevant for Standard mode.
+    # node_pool[0]:
+      # nodes: 0 # Node count per zone for the first node pool. Only relevant for Standard mode.
+  google_kms_crypto_key:
+    key_versions: 0 # Number of key versions.
+    monthly_key_operations: 0 # Monthly number of key operations.
+# resource_usage:
+  ##
+  ## The following usage values apply to individual resources and override any value defined in the resource_type_default_usage section.
+  ## All values are commented-out, you can uncomment resources and customize as needed.
+  ##
+  # module.kubernetes.google_container_cluster.this:
+    # autopilot_vcpu_count: 0.0 # Number of vCPUs used by Autopilot pods. Only relevant for Autopilot mode.
+    # autopilot_memory_gb: 0.0 # Total memory used by Autopilot pods. Only relevant for Autopilot mode.
+    # autopilot_ephemeral_storage_gb: 0.0 # Total ephemeral storage used by Autopilot pods. Only relevant for Autopilot mode.
+    # nodes: 0 # Node count per zone for the default node pool. Only relevant for Standard mode.
+    # node_pool[0]:
+      # nodes: 0 # Node count per zone for the first node pool. Only relevant for Standard mode.
+  # module.kubernetes.google_kms_crypto_key.cluster_database_encryption:
+    # key_versions: 0 # Number of key versions.
+    # monthly_key_operations: 0 # Monthly number of key operations.

--- a/regional/infra/infracost/us-east4-non-production.yml
+++ b/regional/infra/infracost/us-east4-non-production.yml
@@ -3,33 +3,5 @@
 # `infracost breakdown --usage-file infracost-usage.yml [other flags]`
 # See https://infracost.io/usage-file/ for docs
 version: 0.1
-resource_type_default_usage:
-  ##
-  ## The following usage values apply to each resource of the given type, which is useful when you want to define defaults.
-  ## All values are commented-out, you can uncomment resource types and customize as needed.
-  ##
-  google_container_cluster:
-    autopilot_vcpu_count: 0.0 # Number of vCPUs used by Autopilot pods. Only relevant for Autopilot mode.
-    autopilot_memory_gb: 0.0 # Total memory used by Autopilot pods. Only relevant for Autopilot mode.
-    autopilot_ephemeral_storage_gb: 0.0 # Total ephemeral storage used by Autopilot pods. Only relevant for Autopilot mode.
-    # nodes: 0 # Node count per zone for the default node pool. Only relevant for Standard mode.
-    # node_pool[0]:
-      # nodes: 0 # Node count per zone for the first node pool. Only relevant for Standard mode.
-  google_kms_crypto_key:
-    key_versions: 0 # Number of key versions.
-    monthly_key_operations: 0 # Monthly number of key operations.
-# resource_usage:
-  ##
-  ## The following usage values apply to individual resources and override any value defined in the resource_type_default_usage section.
-  ## All values are commented-out, you can uncomment resources and customize as needed.
-  ##
-  # module.kubernetes.google_container_cluster.this:
-    # autopilot_vcpu_count: 0.0 # Number of vCPUs used by Autopilot pods. Only relevant for Autopilot mode.
-    # autopilot_memory_gb: 0.0 # Total memory used by Autopilot pods. Only relevant for Autopilot mode.
-    # autopilot_ephemeral_storage_gb: 0.0 # Total ephemeral storage used by Autopilot pods. Only relevant for Autopilot mode.
-    # nodes: 0 # Node count per zone for the default node pool. Only relevant for Standard mode.
-    # node_pool[0]:
-      # nodes: 0 # Node count per zone for the first node pool. Only relevant for Standard mode.
-  # module.kubernetes.google_kms_crypto_key.cluster_database_encryption:
-    # key_versions: 0 # Number of key versions.
-    # monthly_key_operations: 0 # Monthly number of key operations.
+# resource_type_default_usage: {}
+# resource_usage: {}

--- a/regional/infra/infracost/us-east4-non-production.yml
+++ b/regional/infra/infracost/us-east4-non-production.yml
@@ -4,3 +4,32 @@
 # See https://infracost.io/usage-file/ for docs
 version: 0.1
 resource_type_default_usage:
+  ##
+  ## The following usage values apply to each resource of the given type, which is useful when you want to define defaults.
+  ## All values are commented-out, you can uncomment resource types and customize as needed.
+  ##
+  google_container_cluster:
+    autopilot_vcpu_count: 0.0 # Number of vCPUs used by Autopilot pods. Only relevant for Autopilot mode.
+    autopilot_memory_gb: 0.0 # Total memory used by Autopilot pods. Only relevant for Autopilot mode.
+    autopilot_ephemeral_storage_gb: 0.0 # Total ephemeral storage used by Autopilot pods. Only relevant for Autopilot mode.
+    # nodes: 0 # Node count per zone for the default node pool. Only relevant for Standard mode.
+    # node_pool[0]:
+      # nodes: 0 # Node count per zone for the first node pool. Only relevant for Standard mode.
+  google_kms_crypto_key:
+    key_versions: 0 # Number of key versions.
+    monthly_key_operations: 0 # Monthly number of key operations.
+# resource_usage:
+  ##
+  ## The following usage values apply to individual resources and override any value defined in the resource_type_default_usage section.
+  ## All values are commented-out, you can uncomment resources and customize as needed.
+  ##
+  # module.kubernetes.google_container_cluster.this:
+    # autopilot_vcpu_count: 0.0 # Number of vCPUs used by Autopilot pods. Only relevant for Autopilot mode.
+    # autopilot_memory_gb: 0.0 # Total memory used by Autopilot pods. Only relevant for Autopilot mode.
+    # autopilot_ephemeral_storage_gb: 0.0 # Total ephemeral storage used by Autopilot pods. Only relevant for Autopilot mode.
+    # nodes: 0 # Node count per zone for the default node pool. Only relevant for Standard mode.
+    # node_pool[0]:
+      # nodes: 0 # Node count per zone for the first node pool. Only relevant for Standard mode.
+  # module.kubernetes.google_kms_crypto_key.cluster_database_encryption:
+    # key_versions: 0 # Number of key versions.
+    # monthly_key_operations: 0 # Monthly number of key operations.

--- a/regional/infra/infracost/us-east4-production.yml
+++ b/regional/infra/infracost/us-east4-production.yml
@@ -3,33 +3,5 @@
 # `infracost breakdown --usage-file infracost-usage.yml [other flags]`
 # See https://infracost.io/usage-file/ for docs
 version: 0.1
-resource_type_default_usage:
-  ##
-  ## The following usage values apply to each resource of the given type, which is useful when you want to define defaults.
-  ## All values are commented-out, you can uncomment resource types and customize as needed.
-  ##
-  google_container_cluster:
-    autopilot_vcpu_count: 0.0 # Number of vCPUs used by Autopilot pods. Only relevant for Autopilot mode.
-    autopilot_memory_gb: 0.0 # Total memory used by Autopilot pods. Only relevant for Autopilot mode.
-    autopilot_ephemeral_storage_gb: 0.0 # Total ephemeral storage used by Autopilot pods. Only relevant for Autopilot mode.
-    # nodes: 0 # Node count per zone for the default node pool. Only relevant for Standard mode.
-    # node_pool[0]:
-      # nodes: 0 # Node count per zone for the first node pool. Only relevant for Standard mode.
-  google_kms_crypto_key:
-    key_versions: 0 # Number of key versions.
-    monthly_key_operations: 0 # Monthly number of key operations.
-# resource_usage:
-  ##
-  ## The following usage values apply to individual resources and override any value defined in the resource_type_default_usage section.
-  ## All values are commented-out, you can uncomment resources and customize as needed.
-  ##
-  # module.kubernetes.google_container_cluster.this:
-    # autopilot_vcpu_count: 0.0 # Number of vCPUs used by Autopilot pods. Only relevant for Autopilot mode.
-    # autopilot_memory_gb: 0.0 # Total memory used by Autopilot pods. Only relevant for Autopilot mode.
-    # autopilot_ephemeral_storage_gb: 0.0 # Total ephemeral storage used by Autopilot pods. Only relevant for Autopilot mode.
-    # nodes: 0 # Node count per zone for the default node pool. Only relevant for Standard mode.
-    # node_pool[0]:
-      # nodes: 0 # Node count per zone for the first node pool. Only relevant for Standard mode.
-  # module.kubernetes.google_kms_crypto_key.cluster_database_encryption:
-    # key_versions: 0 # Number of key versions.
-    # monthly_key_operations: 0 # Monthly number of key operations.
+# resource_type_default_usage: {}
+# resource_usage: {}

--- a/regional/infra/infracost/us-east4-production.yml
+++ b/regional/infra/infracost/us-east4-production.yml
@@ -4,3 +4,32 @@
 # See https://infracost.io/usage-file/ for docs
 version: 0.1
 resource_type_default_usage:
+  ##
+  ## The following usage values apply to each resource of the given type, which is useful when you want to define defaults.
+  ## All values are commented-out, you can uncomment resource types and customize as needed.
+  ##
+  google_container_cluster:
+    autopilot_vcpu_count: 0.0 # Number of vCPUs used by Autopilot pods. Only relevant for Autopilot mode.
+    autopilot_memory_gb: 0.0 # Total memory used by Autopilot pods. Only relevant for Autopilot mode.
+    autopilot_ephemeral_storage_gb: 0.0 # Total ephemeral storage used by Autopilot pods. Only relevant for Autopilot mode.
+    # nodes: 0 # Node count per zone for the default node pool. Only relevant for Standard mode.
+    # node_pool[0]:
+      # nodes: 0 # Node count per zone for the first node pool. Only relevant for Standard mode.
+  google_kms_crypto_key:
+    key_versions: 0 # Number of key versions.
+    monthly_key_operations: 0 # Monthly number of key operations.
+# resource_usage:
+  ##
+  ## The following usage values apply to individual resources and override any value defined in the resource_type_default_usage section.
+  ## All values are commented-out, you can uncomment resources and customize as needed.
+  ##
+  # module.kubernetes.google_container_cluster.this:
+    # autopilot_vcpu_count: 0.0 # Number of vCPUs used by Autopilot pods. Only relevant for Autopilot mode.
+    # autopilot_memory_gb: 0.0 # Total memory used by Autopilot pods. Only relevant for Autopilot mode.
+    # autopilot_ephemeral_storage_gb: 0.0 # Total ephemeral storage used by Autopilot pods. Only relevant for Autopilot mode.
+    # nodes: 0 # Node count per zone for the default node pool. Only relevant for Standard mode.
+    # node_pool[0]:
+      # nodes: 0 # Node count per zone for the first node pool. Only relevant for Standard mode.
+  # module.kubernetes.google_kms_crypto_key.cluster_database_encryption:
+    # key_versions: 0 # Number of key versions.
+    # monthly_key_operations: 0 # Monthly number of key operations.

--- a/regional/infra/infracost/us-east4-sandbox.yml
+++ b/regional/infra/infracost/us-east4-sandbox.yml
@@ -3,33 +3,5 @@
 # `infracost breakdown --usage-file infracost-usage.yml [other flags]`
 # See https://infracost.io/usage-file/ for docs
 version: 0.1
-resource_type_default_usage:
-  ##
-  ## The following usage values apply to each resource of the given type, which is useful when you want to define defaults.
-  ## All values are commented-out, you can uncomment resource types and customize as needed.
-  ##
-  google_container_cluster:
-    autopilot_vcpu_count: 0.0 # Number of vCPUs used by Autopilot pods. Only relevant for Autopilot mode.
-    autopilot_memory_gb: 0.0 # Total memory used by Autopilot pods. Only relevant for Autopilot mode.
-    autopilot_ephemeral_storage_gb: 0.0 # Total ephemeral storage used by Autopilot pods. Only relevant for Autopilot mode.
-    # nodes: 0 # Node count per zone for the default node pool. Only relevant for Standard mode.
-    # node_pool[0]:
-      # nodes: 0 # Node count per zone for the first node pool. Only relevant for Standard mode.
-  google_kms_crypto_key:
-    key_versions: 0 # Number of key versions.
-    monthly_key_operations: 0 # Monthly number of key operations.
-# resource_usage:
-  ##
-  ## The following usage values apply to individual resources and override any value defined in the resource_type_default_usage section.
-  ## All values are commented-out, you can uncomment resources and customize as needed.
-  ##
-  # module.kubernetes.google_container_cluster.this:
-    # autopilot_vcpu_count: 0.0 # Number of vCPUs used by Autopilot pods. Only relevant for Autopilot mode.
-    # autopilot_memory_gb: 0.0 # Total memory used by Autopilot pods. Only relevant for Autopilot mode.
-    # autopilot_ephemeral_storage_gb: 0.0 # Total ephemeral storage used by Autopilot pods. Only relevant for Autopilot mode.
-    # nodes: 0 # Node count per zone for the default node pool. Only relevant for Standard mode.
-    # node_pool[0]:
-      # nodes: 0 # Node count per zone for the first node pool. Only relevant for Standard mode.
-  # module.kubernetes.google_kms_crypto_key.cluster_database_encryption:
-    # key_versions: 0 # Number of key versions.
-    # monthly_key_operations: 0 # Monthly number of key operations.
+# resource_type_default_usage: {}
+# resource_usage: {}

--- a/regional/infra/infracost/us-east4-sandbox.yml
+++ b/regional/infra/infracost/us-east4-sandbox.yml
@@ -4,3 +4,32 @@
 # See https://infracost.io/usage-file/ for docs
 version: 0.1
 resource_type_default_usage:
+  ##
+  ## The following usage values apply to each resource of the given type, which is useful when you want to define defaults.
+  ## All values are commented-out, you can uncomment resource types and customize as needed.
+  ##
+  google_container_cluster:
+    autopilot_vcpu_count: 0.0 # Number of vCPUs used by Autopilot pods. Only relevant for Autopilot mode.
+    autopilot_memory_gb: 0.0 # Total memory used by Autopilot pods. Only relevant for Autopilot mode.
+    autopilot_ephemeral_storage_gb: 0.0 # Total ephemeral storage used by Autopilot pods. Only relevant for Autopilot mode.
+    # nodes: 0 # Node count per zone for the default node pool. Only relevant for Standard mode.
+    # node_pool[0]:
+      # nodes: 0 # Node count per zone for the first node pool. Only relevant for Standard mode.
+  google_kms_crypto_key:
+    key_versions: 0 # Number of key versions.
+    monthly_key_operations: 0 # Monthly number of key operations.
+# resource_usage:
+  ##
+  ## The following usage values apply to individual resources and override any value defined in the resource_type_default_usage section.
+  ## All values are commented-out, you can uncomment resources and customize as needed.
+  ##
+  # module.kubernetes.google_container_cluster.this:
+    # autopilot_vcpu_count: 0.0 # Number of vCPUs used by Autopilot pods. Only relevant for Autopilot mode.
+    # autopilot_memory_gb: 0.0 # Total memory used by Autopilot pods. Only relevant for Autopilot mode.
+    # autopilot_ephemeral_storage_gb: 0.0 # Total ephemeral storage used by Autopilot pods. Only relevant for Autopilot mode.
+    # nodes: 0 # Node count per zone for the default node pool. Only relevant for Standard mode.
+    # node_pool[0]:
+      # nodes: 0 # Node count per zone for the first node pool. Only relevant for Standard mode.
+  # module.kubernetes.google_kms_crypto_key.cluster_database_encryption:
+    # key_versions: 0 # Number of key versions.
+    # monthly_key_operations: 0 # Monthly number of key operations.

--- a/regional/infra/main.tf
+++ b/regional/infra/main.tf
@@ -56,5 +56,5 @@ module "kubernetes" {
   project_number                = local.global.project_number
   region                        = var.region
   services_secondary_range_name = "services-k8s-services-${var.region}"
-  subnet                        = "services-subnet-${var.region}"
+  subnet                        = "services-${var.region}"
 }

--- a/regional/infra/main.tf
+++ b/regional/infra/main.tf
@@ -26,3 +26,35 @@ data "terraform_remote_state" "global" {
 
   workspace = "global-${var.environment}"
 }
+
+# Google Kubernetes Engine Module (osinfra.io)
+# https://github.com/osinfra-io/terraform-google-kubernetes-engine
+
+module "kubernetes" {
+  source = "github.com/osinfra-io/terraform-google-kubernetes-engine//regional?ref=v0.1.0"
+
+  cluster_autoscaling = {
+    enabled = true
+  }
+
+  cluster_prefix               = "services"
+  cluster_secondary_range_name = "services-k8s-pods-${var.region}"
+  enable_deletion_protection   = false
+  host_project_id              = var.host_project_id
+
+  labels = {
+    env      = var.environment
+    module   = "google-cloud-kubernetes"
+    platform = "google-cloud-kubernetes"
+    team     = "platform-google-cloud-kubernetes"
+  }
+
+  network = "standard-shared"
+
+  master_ipv4_cidr_block        = var.master_ipv4_cidr_block
+  project_id                    = local.global.project_id
+  project_number                = local.global.project_number
+  region                        = var.region
+  services_secondary_range_name = "services-k8s-services-${var.region}"
+  subnet                        = "services-subnet-${var.region}"
+}

--- a/regional/infra/main.tf
+++ b/regional/infra/main.tf
@@ -33,6 +33,8 @@ data "terraform_remote_state" "global" {
 module "kubernetes" {
   source = "github.com/osinfra-io/terraform-google-kubernetes-engine//regional?ref=v0.1.0"
 
+  count = var.enable_cluster ? 1 : 0
+
   cluster_autoscaling = {
     enabled = true
   }

--- a/regional/infra/main.tf
+++ b/regional/infra/main.tf
@@ -43,10 +43,10 @@ module "kubernetes" {
   host_project_id              = var.host_project_id
 
   labels = {
-    env      = var.environment
-    module   = "google-cloud-kubernetes"
-    platform = "google-cloud-kubernetes"
-    team     = "platform-google-cloud-kubernetes"
+    env        = var.environment
+    repository = "google-cloud-kubernetes"
+    platform   = "google-cloud-kubernetes"
+    team       = "platform-google-cloud-kubernetes"
   }
 
   network = "standard-shared"

--- a/regional/infra/tfvars/us-east1-non-production.tfvars
+++ b/regional/infra/tfvars/us-east1-non-production.tfvars
@@ -1,3 +1,5 @@
-environment   = "non-production"
-region        = "us-east1"
-remote_bucket = "plt-k8s-3bfe-nonprod"
+environment            = "non-production"
+host_project_id        = "plt-lz-networking-tf81-nonprod"
+master_ipv4_cidr_block = "10.61.224.0/28"
+region                 = "us-east1"
+remote_bucket          = "plt-k8s-3bfe-nonprod"

--- a/regional/infra/tfvars/us-east1-production.tfvars
+++ b/regional/infra/tfvars/us-east1-production.tfvars
@@ -1,3 +1,5 @@
-environment   = "production"
-region        = "us-east1"
-remote_bucket = "plt-k8s-e194-prod"
+environment            = "production"
+host_project_id        = "plt-lz-networking-tfcb-prod"
+master_ipv4_cidr_block = "10.61.224.0/28"
+region                 = "us-east1"
+remote_bucket          = "plt-k8s-e194-prod"

--- a/regional/infra/tfvars/us-east1-sandbox.tfvars
+++ b/regional/infra/tfvars/us-east1-sandbox.tfvars
@@ -1,3 +1,4 @@
+enable_cluster         = true
 host_project_id        = "plt-lz-networking-tfd8-sb"
 master_ipv4_cidr_block = "10.61.224.0/28"
 region                 = "us-east1"

--- a/regional/infra/tfvars/us-east1-sandbox.tfvars
+++ b/regional/infra/tfvars/us-east1-sandbox.tfvars
@@ -1,2 +1,4 @@
-region        = "us-east1"
-remote_bucket = "plt-k8s-2c8b-sb"
+host_project_id        = "plt-lz-networking-tfd8-sb"
+master_ipv4_cidr_block = "10.61.224.0/28"
+region                 = "us-east1"
+remote_bucket          = "plt-k8s-2c8b-sb"

--- a/regional/infra/tfvars/us-east1-sandbox.tfvars
+++ b/regional/infra/tfvars/us-east1-sandbox.tfvars
@@ -1,4 +1,4 @@
-enable_cluster         = true
+enable_cluster         = false
 host_project_id        = "plt-lz-networking-tfd8-sb"
 master_ipv4_cidr_block = "10.61.224.0/28"
 region                 = "us-east1"

--- a/regional/infra/tfvars/us-east4-non-production.tfvars
+++ b/regional/infra/tfvars/us-east4-non-production.tfvars
@@ -1,3 +1,5 @@
-environment   = "non-production"
-region        = "us-east4"
-remote_bucket = "plt-k8s-3bfe-nonprod"
+environment            = "non-production"
+host_project_id        = "plt-lz-networking-tf81-nonprod"
+master_ipv4_cidr_block = "10.61.224.16/28"
+region                 = "us-east4"
+remote_bucket          = "plt-k8s-3bfe-nonprod"

--- a/regional/infra/tfvars/us-east4-production.tfvars
+++ b/regional/infra/tfvars/us-east4-production.tfvars
@@ -1,3 +1,5 @@
-environment   = "production"
-region        = "us-east4"
-remote_bucket = "plt-k8s-e194-prod"
+environment            = "production"
+host_project_id        = "plt-lz-networking-tfcb-prod"
+master_ipv4_cidr_block = "10.61.224.16/28"
+region                 = "us-east4"
+remote_bucket          = "plt-k8s-e194-prod"

--- a/regional/infra/tfvars/us-east4-sandbox.tfvars
+++ b/regional/infra/tfvars/us-east4-sandbox.tfvars
@@ -1,2 +1,4 @@
-region        = "us-east4"
-remote_bucket = "plt-k8s-2c8b-sb"
+host_project_id        = "plt-lz-networking-tfd8-sb"
+master_ipv4_cidr_block = "10.61.224.16/28"
+region                 = "us-east4"
+remote_bucket          = "plt-k8s-2c8b-sb"

--- a/regional/infra/variables.tf
+++ b/regional/infra/variables.tf
@@ -1,3 +1,9 @@
+variable "enable_cluster" {
+  description = "Enable the creation of the GKE cluster"
+  type        = bool
+  default     = false
+}
+
 variable "environment" {
   description = "The environment for example: `sandbox`, `non-production`, `production`"
   type        = string

--- a/regional/infra/variables.tf
+++ b/regional/infra/variables.tf
@@ -4,6 +4,16 @@ variable "environment" {
   default     = "sandbox"
 }
 
+variable "host_project_id" {
+  description = "Host project for the shared VPC"
+  type        = string
+}
+
+variable "master_ipv4_cidr_block" {
+  description = "The IP range in CIDR notation to use for the hosted master network"
+  type        = string
+}
+
 variable "region" {
   description = "The region to deploy the resources to"
   type        = string


### PR DESCRIPTION
This pull request adds clusters to the codebase. Clusters are defined with their respective host project IDs, master IPv4 CIDR block, region, and remote bucket. This change enables the deployment of resources to different environments such as production, non-production, and sandbox. The clusters are created using the Google Kubernetes Engine module from osinfra.io. The module provides features like cluster autoscaling and labels for better organization. This PR also includes updates to the usage file for infracost.io.

Fixes #1 