### PR TITLE
Comment out unused cluster links in Istio configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,5 +40,5 @@ repos:
         args:
           - --download-external-modules=true
           - --skip-check
-          - "CKV_TF_1,CKV_TF_2"
+          - "CKV_TF_1"
           - --quiet

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,5 +40,5 @@ repos:
         args:
           - --download-external-modules=true
           - --skip-check
-          - "CKV_TF_1"
+          - "CKV_TF_1,CKV_TF_2"
           - --quiet

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ No providers.
 | <a name="module_datadog"></a> [datadog](#module\_datadog) | github.com/osinfra-io/terraform-datadog-google-integration | v0.3.0 |
 | <a name="module_helpers"></a> [helpers](#module\_helpers) | github.com/osinfra-io/terraform-core-helpers//root | v0.1.2 |
 | <a name="module_kubernetes_engine"></a> [kubernetes\_engine](#module\_kubernetes\_engine) | github.com/osinfra-io/terraform-google-kubernetes-engine | v0.2.0 |
-| <a name="module_kubernetes_istio"></a> [kubernetes\_istio](#module\_kubernetes\_istio) | github.com/osinfra-io/terraform-kubernetes-istio | v0.1.5 |
+| <a name="module_kubernetes_istio"></a> [kubernetes\_istio](#module\_kubernetes\_istio) | github.com/osinfra-io/terraform-kubernetes-istio | v0.1.6 |
 | <a name="module_project"></a> [project](#module\_project) | github.com/osinfra-io/terraform-google-project | v0.4.5 |
 
 #### Resources

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ No providers.
 |------|--------|---------|
 | <a name="module_datadog"></a> [datadog](#module\_datadog) | github.com/osinfra-io/terraform-datadog-google-integration | v0.3.0 |
 | <a name="module_helpers"></a> [helpers](#module\_helpers) | github.com/osinfra-io/terraform-core-helpers//root | v0.1.2 |
-| <a name="module_kubernetes_engine"></a> [kubernetes\_engine](#module\_kubernetes\_engine) | github.com/osinfra-io/terraform-google-kubernetes-engine | v0.2.0 |
+| <a name="module_kubernetes_engine"></a> [kubernetes\_engine](#module\_kubernetes\_engine) | github.com/osinfra-io/terraform-google-kubernetes-engine | fix |
 | <a name="module_kubernetes_istio"></a> [kubernetes\_istio](#module\_kubernetes\_istio) | github.com/osinfra-io/terraform-kubernetes-istio | v0.1.6 |
 | <a name="module_project"></a> [project](#module\_project) | github.com/osinfra-io/terraform-google-project | v0.4.5 |
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ No providers.
 |------|--------|---------|
 | <a name="module_datadog"></a> [datadog](#module\_datadog) | github.com/osinfra-io/terraform-datadog-google-integration | v0.3.0 |
 | <a name="module_helpers"></a> [helpers](#module\_helpers) | github.com/osinfra-io/terraform-core-helpers//root | v0.1.2 |
-| <a name="module_kubernetes_engine"></a> [kubernetes\_engine](#module\_kubernetes\_engine) | github.com/osinfra-io/terraform-google-kubernetes-engine | fix |
+| <a name="module_kubernetes_engine"></a> [kubernetes\_engine](#module\_kubernetes\_engine) | github.com/osinfra-io/terraform-google-kubernetes-engine | v0.2.1 |
 | <a name="module_kubernetes_istio"></a> [kubernetes\_istio](#module\_kubernetes\_istio) | github.com/osinfra-io/terraform-kubernetes-istio | v0.1.6 |
 | <a name="module_project"></a> [project](#module\_project) | github.com/osinfra-io/terraform-google-project | v0.4.5 |
 

--- a/main.tf
+++ b/main.tf
@@ -53,7 +53,7 @@ module "project" {
 # https://github.com/osinfra-io/terraform-google-kubernetes-engine
 
 module "kubernetes_engine" {
-  source = "github.com/osinfra-io/terraform-google-kubernetes-engine?ref=fix"
+  source = "github.com/osinfra-io/terraform-google-kubernetes-engine?ref=v0.2.1"
 
   namespaces = var.kubernetes_engine_namespaces
   project    = module.project.id

--- a/main.tf
+++ b/main.tf
@@ -44,6 +44,7 @@ module "project" {
     "multiclusterservicediscovery.googleapis.com",
     "servicenetworking.googleapis.com",
     "serviceusage.googleapis.com",
+    "sqladmin.googleapis.com",
     "trafficdirector.googleapis.com"
   ]
 }

--- a/main.tf
+++ b/main.tf
@@ -38,6 +38,7 @@ module "project" {
     "dns.googleapis.com",
     "gkehub.googleapis.com",
     "iam.googleapis.com",
+    "iap.googleapis.com",
     "monitoring.googleapis.com",
     "multiclusteringress.googleapis.com",
     "multiclusterservicediscovery.googleapis.com",

--- a/main.tf
+++ b/main.tf
@@ -53,7 +53,7 @@ module "project" {
 # https://github.com/osinfra-io/terraform-google-kubernetes-engine
 
 module "kubernetes_engine" {
-  source = "github.com/osinfra-io/terraform-google-kubernetes-engine?ref=v0.2.0"
+  source = "github.com/osinfra-io/terraform-google-kubernetes-engine?ref=fix"
 
   namespaces = var.kubernetes_engine_namespaces
   project    = module.project.id

--- a/regional/README.md
+++ b/regional/README.md
@@ -16,7 +16,7 @@ No requirements.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_helpers"></a> [helpers](#module\_helpers) | github.com/osinfra-io/terraform-core-helpers//root | v0.1.2 |
-| <a name="module_kubernetes_engine_regional"></a> [kubernetes\_engine\_regional](#module\_kubernetes\_engine\_regional) | github.com/osinfra-io/terraform-google-kubernetes-engine//regional | v0.2.0 |
+| <a name="module_kubernetes_engine_regional"></a> [kubernetes\_engine\_regional](#module\_kubernetes\_engine\_regional) | github.com/osinfra-io/terraform-google-kubernetes-engine//regional | v0.2.1 |
 
 ## Resources
 

--- a/regional/istio/main.tf
+++ b/regional/istio/main.tf
@@ -30,12 +30,12 @@ module "kubernetes_istio" {
   labels                     = module.helpers.labels
 
   multi_cluster_service_clusters = [
-    {
-      "link" = "us-east1/plt-us-east1-b"
-    },
-    {
-      "link" = "us-east4/plt-us-east4-a"
-    }
+    # {
+    #   "link" = "us-east1/plt-us-east1-b"
+    # },
+    # {
+    #   "link" = "us-east4/plt-us-east4-a"
+    # }
   ]
 
   pilot_cpu_limits      = var.kubernetes_istio_pilot_cpu_limits

--- a/regional/main.tf
+++ b/regional/main.tf
@@ -16,7 +16,7 @@ data "terraform_remote_state" "main" {
 # https://github.com/osinfra-io/terraform-google-kubernetes-engine
 
 module "kubernetes_engine_regional" {
-  source = "github.com/osinfra-io/terraform-google-kubernetes-engine//regional?ref=v0.2.0"
+  source = "github.com/osinfra-io/terraform-google-kubernetes-engine//regional?ref=v0.2.1"
 
   cluster_prefix                = "plt"
   cluster_secondary_range_name  = "k8s-secondary-pods"

--- a/regional/onboarding/README.md
+++ b/regional/onboarding/README.md
@@ -17,7 +17,7 @@ No requirements.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_helpers"></a> [helpers](#module\_helpers) | github.com/osinfra-io/terraform-core-helpers//root | v0.1.2 |
-| <a name="module_kubernetes_engine_onboarding"></a> [kubernetes\_engine\_onboarding](#module\_kubernetes\_engine\_onboarding) | github.com/osinfra-io/terraform-google-kubernetes-engine//regional/onboarding | v0.2.0 |
+| <a name="module_kubernetes_engine_onboarding"></a> [kubernetes\_engine\_onboarding](#module\_kubernetes\_engine\_onboarding) | github.com/osinfra-io/terraform-google-kubernetes-engine//regional/onboarding | v0.2.1 |
 
 ## Resources
 

--- a/regional/onboarding/main.tf
+++ b/regional/onboarding/main.tf
@@ -16,7 +16,7 @@ data "terraform_remote_state" "main" {
 # https://github.com/osinfra-io/terraform-google-kubernetes-engine
 
 module "kubernetes_engine_onboarding" {
-  source = "github.com/osinfra-io/terraform-google-kubernetes-engine//regional/onboarding?ref=v0.2.0"
+  source = "github.com/osinfra-io/terraform-google-kubernetes-engine//regional/onboarding?ref=v0.2.1"
 
   namespaces                               = var.kubernetes_engine_namespaces
   project                                  = data.google_project.this.project_id

--- a/regional/tfvars/us-east1-b-sandbox.tfvars
+++ b/regional/tfvars/us-east1-b-sandbox.tfvars
@@ -1,9 +1,9 @@
 kubernetes_engine_enable_gke_hub_host = true
 
 kubernetes_engine_gke_hub_memberships = {
-  "plt-us-east4-a" = {
-    cluster_id = "projects/plt-k8s-tf39-sb/locations/us-east4/clusters/plt-us-east4-a"
-  }
+  # "plt-us-east4-a" = {
+  #   cluster_id = "projects/plt-k8s-tf39-sb/locations/us-east4/clusters/plt-us-east4-a"
+  # }
 }
 
 kubernetes_engine_master_ipv4_cidr_block = "10.63.240.0/28"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **Configuration Updates**
  - Commented out cluster links in Istio configuration
  - Removed GKE Hub membership for a specific cluster

- **Service Additions**
  - Enabled Identity-Aware Proxy (IAP) service
  - Enabled SQL Admin service

- **Module Version Updates**
  - Upgraded Kubernetes Engine modules to v0.2.1
  - Updated Kubernetes Istio module to v0.1.6
<!-- end of auto-generated comment: release notes by coderabbit.ai -->