### PR TITLE
Bump kubernetes-engine and datadog operator versions to v0.2.4 and v0.1.7 respectively

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ No providers.
 | <a name="module_datadog"></a> [datadog](#module\_datadog) | github.com/osinfra-io/terraform-datadog-google-integration | v0.3.0 |
 | <a name="module_helpers"></a> [helpers](#module\_helpers) | github.com/osinfra-io/terraform-core-helpers//root | v0.1.2 |
 | <a name="module_kubernetes_cert_manager"></a> [kubernetes\_cert\_manager](#module\_kubernetes\_cert\_manager) | github.com/osinfra-io/terraform-kubernetes-cert-manager | v0.1.5 |
-| <a name="module_kubernetes_engine"></a> [kubernetes\_engine](#module\_kubernetes\_engine) | github.com/osinfra-io/terraform-google-kubernetes-engine | v0.2.3 |
+| <a name="module_kubernetes_engine"></a> [kubernetes\_engine](#module\_kubernetes\_engine) | github.com/osinfra-io/terraform-google-kubernetes-engine | v0.2.4 |
 | <a name="module_kubernetes_istio"></a> [kubernetes\_istio](#module\_kubernetes\_istio) | github.com/osinfra-io/terraform-kubernetes-istio | v0.1.8 |
 | <a name="module_project"></a> [project](#module\_project) | github.com/osinfra-io/terraform-google-project | v0.4.5 |
 

--- a/main.tf
+++ b/main.tf
@@ -23,7 +23,7 @@ module "kubernetes_cert_manager" {
 # https://github.com/osinfra-io/terraform-google-kubernetes-engine
 
 module "kubernetes_engine" {
-  source = "github.com/osinfra-io/terraform-google-kubernetes-engine?ref=v0.2.3"
+  source = "github.com/osinfra-io/terraform-google-kubernetes-engine?ref=v0.2.4"
 
   labels                     = module.helpers.labels
   namespaces                 = var.kubernetes_engine_namespaces

--- a/regional/README.md
+++ b/regional/README.md
@@ -16,7 +16,7 @@ No requirements.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_helpers"></a> [helpers](#module\_helpers) | github.com/osinfra-io/terraform-core-helpers//root | v0.1.2 |
-| <a name="module_kubernetes_engine_regional"></a> [kubernetes\_engine\_regional](#module\_kubernetes\_engine\_regional) | github.com/osinfra-io/terraform-google-kubernetes-engine//regional | v0.2.3 |
+| <a name="module_kubernetes_engine_regional"></a> [kubernetes\_engine\_regional](#module\_kubernetes\_engine\_regional) | github.com/osinfra-io/terraform-google-kubernetes-engine//regional | v0.2.4 |
 
 ## Resources
 
@@ -40,5 +40,5 @@ No requirements.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_kubernetes_engine_service_account_gke_operations_email"></a> [kubernetes\_engine\_service\_account\_gke\_operations\_email](#output\_kubernetes\_engine\_service\_account\_gke\_operations\_email) | The email address of the Kubernetes minimum privilege service account for the cluster |
+| <a name="output_kubernetes_engine_service_account_default_node_email"></a> [kubernetes\_engine\_service\_account\_default\_node\_email](#output\_kubernetes\_engine\_service\_account\_default\_node\_email) | The email address of the Kubernetes minimum privilege service account for the cluster |
 <!-- END_TF_DOCS -->

--- a/regional/datadog/README.md
+++ b/regional/datadog/README.md
@@ -16,7 +16,7 @@ No requirements.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_helpers"></a> [helpers](#module\_helpers) | github.com/osinfra-io/terraform-core-helpers//root | v0.1.2 |
-| <a name="module_kubernetes_datadog_operator"></a> [kubernetes\_datadog\_operator](#module\_kubernetes\_datadog\_operator) | github.com/osinfra-io/terraform-kubernetes-datadog-operator//regional | v0.1.6 |
+| <a name="module_kubernetes_datadog_operator"></a> [kubernetes\_datadog\_operator](#module\_kubernetes\_datadog\_operator) | github.com/osinfra-io/terraform-kubernetes-datadog-operator//regional | v0.1.7 |
 
 ## Resources
 

--- a/regional/datadog/main.tf
+++ b/regional/datadog/main.tf
@@ -2,7 +2,7 @@
 # https://github.com/osinfra-io/terraform-kubernetes-datadog-operator
 
 module "kubernetes_datadog_operator" {
-  source = "github.com/osinfra-io/terraform-kubernetes-datadog-operator//regional?ref=v0.1.6"
+  source = "github.com/osinfra-io/terraform-kubernetes-datadog-operator//regional?ref=v0.1.7"
 
   api_key        = var.datadog_api_key
   app_key        = var.datadog_app_key

--- a/regional/datadog/manifests/README.md
+++ b/regional/datadog/manifests/README.md
@@ -16,7 +16,7 @@ No requirements.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_helpers"></a> [helpers](#module\_helpers) | github.com/osinfra-io/terraform-core-helpers//root | v0.1.2 |
-| <a name="module_kubernetes_datadog_operator_manifests"></a> [kubernetes\_datadog\_operator\_manifests](#module\_kubernetes\_datadog\_operator\_manifests) | github.com/osinfra-io/terraform-kubernetes-datadog-operator//regional/manifests | v0.1.6 |
+| <a name="module_kubernetes_datadog_operator_manifests"></a> [kubernetes\_datadog\_operator\_manifests](#module\_kubernetes\_datadog\_operator\_manifests) | github.com/osinfra-io/terraform-kubernetes-datadog-operator//regional/manifests | v0.1.7 |
 
 ## Resources
 

--- a/regional/datadog/manifests/main.tf
+++ b/regional/datadog/manifests/main.tf
@@ -2,7 +2,7 @@
 # https://github.com/osinfra-io/terraform-kubernetes-datadog-operator
 
 module "kubernetes_datadog_operator_manifests" {
-  source = "github.com/osinfra-io/terraform-kubernetes-datadog-operator//regional/manifests?ref=v0.1.6"
+  source = "github.com/osinfra-io/terraform-kubernetes-datadog-operator//regional/manifests?ref=v0.1.7"
 
   api_key        = var.datadog_api_key
   app_key        = var.datadog_app_key

--- a/regional/istio/test/README.md
+++ b/regional/istio/test/README.md
@@ -40,7 +40,7 @@ No requirements.
 | <a name="input_datadog_api_key"></a> [datadog\_api\_key](#input\_datadog\_api\_key) | Datadog API key | `string` | n/a | yes |
 | <a name="input_datadog_app_key"></a> [datadog\_app\_key](#input\_datadog\_app\_key) | Datadog APP key | `string` | n/a | yes |
 | <a name="input_istio_test_replicas"></a> [istio\_test\_replicas](#input\_istio\_test\_replicas) | The number of replicas for the istio-test deployment | `number` | `1` | no |
-| <a name="input_istio_test_version"></a> [istio\_test\_version](#input\_istio\_test\_version) | The version of the istio-test deployment | `string` | `"v0.3.1"` | no |
+| <a name="input_istio_test_version"></a> [istio\_test\_version](#input\_istio\_test\_version) | The version of the istio-test deployment | `string` | `"v0.3.2"` | no |
 
 ## Outputs
 

--- a/regional/istio/test/variables.tf
+++ b/regional/istio/test/variables.tf
@@ -19,5 +19,5 @@ variable "istio_test_replicas" {
 variable "istio_test_version" {
   description = "The version of the istio-test deployment"
   type        = string
-  default     = "v0.3.1"
+  default     = "v0.3.2"
 }

--- a/regional/main.tf
+++ b/regional/main.tf
@@ -16,7 +16,7 @@ data "terraform_remote_state" "main" {
 # https://github.com/osinfra-io/terraform-google-kubernetes-engine
 
 module "kubernetes_engine_regional" {
-  source = "github.com/osinfra-io/terraform-google-kubernetes-engine//regional?ref=v0.2.3"
+  source = "github.com/osinfra-io/terraform-google-kubernetes-engine//regional?ref=v0.2.4"
 
   cluster_prefix                = "plt"
   cluster_secondary_range_name  = "k8s-secondary-pods"

--- a/regional/onboarding/README.md
+++ b/regional/onboarding/README.md
@@ -17,7 +17,7 @@ No requirements.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_helpers"></a> [helpers](#module\_helpers) | github.com/osinfra-io/terraform-core-helpers//root | v0.1.2 |
-| <a name="module_kubernetes_engine_onboarding"></a> [kubernetes\_engine\_onboarding](#module\_kubernetes\_engine\_onboarding) | github.com/osinfra-io/terraform-google-kubernetes-engine//regional/onboarding | v0.2.2 |
+| <a name="module_kubernetes_engine_onboarding"></a> [kubernetes\_engine\_onboarding](#module\_kubernetes\_engine\_onboarding) | github.com/osinfra-io/terraform-google-kubernetes-engine//regional/onboarding | v0.2.4 |
 
 ## Resources
 

--- a/regional/onboarding/main.tf
+++ b/regional/onboarding/main.tf
@@ -16,7 +16,7 @@ data "terraform_remote_state" "main" {
 # https://github.com/osinfra-io/terraform-google-kubernetes-engine
 
 module "kubernetes_engine_onboarding" {
-  source = "github.com/osinfra-io/terraform-google-kubernetes-engine//regional/onboarding?ref=v0.2.2"
+  source = "github.com/osinfra-io/terraform-google-kubernetes-engine//regional/onboarding?ref=v0.2.4"
 
   namespaces                               = var.kubernetes_engine_namespaces
   project                                  = data.google_project.this.project_id

--- a/regional/outputs.tf
+++ b/regional/outputs.tf
@@ -1,7 +1,7 @@
 # Output Values
 # https://www.terraform.io/language/values/outputs
 
-output "kubernetes_engine_service_account_gke_operations_email" {
+output "kubernetes_engine_service_account_default_node_email" {
   description = "The email address of the Kubernetes minimum privilege service account for the cluster"
-  value       = module.kubernetes_engine_regional.service_account_gke_operations_email
+  value       = module.kubernetes_engine_regional.service_account_default_node_email
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
	- Upgraded several Terraform module versions and source references to more recent releases.
	- Updated the default value for the istio-test deployment configuration.
	- Renamed a service account email output for improved clarity.
- Documentation
	- Revised version information and naming conventions in the provided documentation to reflect these upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->