### PR TITLE
Implement state and plan encryption configuration

### DIFF
--- a/.github/workflows/sandbox-destroy.yml
+++ b/.github/workflows/sandbox-destroy.yml
@@ -13,12 +13,13 @@ permissions:
 jobs:
   us_east1_b_istio_test:
     name: "Istio Test: us-east1-b"
-    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@367d86eecaab18bb7fae7f5fa17fe7001df13f16
+    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@e3c59e43f2458550c7f13b6369fb6978b6f42c6e # v0.2.9
     if: github.actor != 'dependabot[bot]'
     with:
       checkout_ref: ${{ github.ref }}
       github_environment: "Sandbox Istio Test: us-east1-b"
       service_account: plt-k8s-github@plt-lz-backend-tf69-sb.iam.gserviceaccount.com
+      opentofu_kms_encryption_key: projects/plt-lz-backend-tf69-sb/locations/us/keyRings/state-encryption/cryptoKeys/default
       opentofu_plan_args: -destroy -var-file=tfvars/us-east1-b-sandbox.tfvars
       opentofu_state_bucket: plt-k8s-0bf7-sb
       opentofu_version: ${{ vars.OPENTOFU_VERSION }}
@@ -26,19 +27,19 @@ jobs:
       working_directory: regional/istio/test
       workload_identity_provider: projects/746490462722/locations/global/workloadIdentityPools/github-actions/providers/github-actions-oidc
     secrets:
-      gpg_passphrase: ${{ secrets.GPG_PASSPHRASE }}
       opentofu_plan_secret_args: >-
         -var=datadog_api_key=${{ secrets.DATADOG_API_KEY }}
         -var=datadog_app_key=${{ secrets.DATADOG_APP_KEY }}
 
   us_east4_a_istio_test:
     name: "Istio Test: us-east4-a"
-    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@367d86eecaab18bb7fae7f5fa17fe7001df13f16
+    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@e3c59e43f2458550c7f13b6369fb6978b6f42c6e # v0.2.9
     if: github.actor != 'dependabot[bot]'
     with:
       checkout_ref: ${{ github.ref }}
       github_environment: "Sandbox Istio Test: us-east4-a"
       service_account: plt-k8s-github@plt-lz-backend-tf69-sb.iam.gserviceaccount.com
+      opentofu_kms_encryption_key: projects/plt-lz-backend-tf69-sb/locations/us/keyRings/state-encryption/cryptoKeys/default
       opentofu_plan_args: -destroy -var-file=tfvars/us-east4-a-sandbox.tfvars
       opentofu_state_bucket: plt-k8s-0bf7-sb
       opentofu_version: ${{ vars.OPENTOFU_VERSION }}
@@ -46,19 +47,19 @@ jobs:
       working_directory: regional/istio/test
       workload_identity_provider: projects/746490462722/locations/global/workloadIdentityPools/github-actions/providers/github-actions-oidc
     secrets:
-      gpg_passphrase: ${{ secrets.GPG_PASSPHRASE }}
       opentofu_plan_secret_args: >-
         -var=datadog_api_key=${{ secrets.DATADOG_API_KEY }}
         -var=datadog_app_key=${{ secrets.DATADOG_APP_KEY }}
 
   us_east1_b_datadog_manifests:
     name: "Datadog Manifests: us-east1-b"
-    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@367d86eecaab18bb7fae7f5fa17fe7001df13f16
+    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@e3c59e43f2458550c7f13b6369fb6978b6f42c6e # v0.2.9
     if: github.actor != 'dependabot[bot]'
     with:
       checkout_ref: ${{ github.ref }}
       github_environment: "Sandbox Datadog Manifests: us-east1-b"
       service_account: plt-k8s-github@plt-lz-backend-tf69-sb.iam.gserviceaccount.com
+      opentofu_kms_encryption_key: projects/plt-lz-backend-tf69-sb/locations/us/keyRings/state-encryption/cryptoKeys/default
       opentofu_plan_args: -destroy -var-file=tfvars/us-east1-b-sandbox.tfvars
       opentofu_state_bucket: plt-k8s-0bf7-sb
       opentofu_version: ${{ vars.OPENTOFU_VERSION }}
@@ -66,19 +67,19 @@ jobs:
       working_directory: regional/datadog/manifests
       workload_identity_provider: projects/746490462722/locations/global/workloadIdentityPools/github-actions/providers/github-actions-oidc
     secrets:
-      gpg_passphrase: ${{ secrets.GPG_PASSPHRASE }}
       opentofu_plan_secret_args: >-
         -var=datadog_api_key=${{ secrets.DATADOG_API_KEY }}
         -var=datadog_app_key=${{ secrets.DATADOG_APP_KEY }}
 
   us_east4_a_datadog_manifests:
     name: "Datadog Manifests: us-east4-a"
-    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@367d86eecaab18bb7fae7f5fa17fe7001df13f16
+    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@e3c59e43f2458550c7f13b6369fb6978b6f42c6e # v0.2.9
     if: github.actor != 'dependabot[bot]'
     with:
       checkout_ref: ${{ github.ref }}
       github_environment: "Sandbox Datadog Manifests: us-east4-a"
       service_account: plt-k8s-github@plt-lz-backend-tf69-sb.iam.gserviceaccount.com
+      opentofu_kms_encryption_key: projects/plt-lz-backend-tf69-sb/locations/us/keyRings/state-encryption/cryptoKeys/default
       opentofu_plan_args: -destroy -var-file=tfvars/us-east4-a-sandbox.tfvars
       opentofu_state_bucket: plt-k8s-0bf7-sb
       opentofu_version: ${{ vars.OPENTOFU_VERSION }}
@@ -86,20 +87,20 @@ jobs:
       working_directory: regional/datadog/manifests
       workload_identity_provider: projects/746490462722/locations/global/workloadIdentityPools/github-actions/providers/github-actions-oidc
     secrets:
-      gpg_passphrase: ${{ secrets.GPG_PASSPHRASE }}
       opentofu_plan_secret_args: >-
         -var=datadog_api_key=${{ secrets.DATADOG_API_KEY }}
         -var=datadog_app_key=${{ secrets.DATADOG_APP_KEY }}
 
   us_east1_b_datadog:
     name: "Datadog: us-east1-b"
-    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@367d86eecaab18bb7fae7f5fa17fe7001df13f16
+    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@e3c59e43f2458550c7f13b6369fb6978b6f42c6e # v0.2.9
     if: github.actor != 'dependabot[bot]'
     needs: us_east1_b_datadog_manifests
     with:
       checkout_ref: ${{ github.ref }}
       github_environment: "Sandbox Datadog: us-east1-b"
       service_account: plt-k8s-github@plt-lz-backend-tf69-sb.iam.gserviceaccount.com
+      opentofu_kms_encryption_key: projects/plt-lz-backend-tf69-sb/locations/us/keyRings/state-encryption/cryptoKeys/default
       opentofu_plan_args: -destroy -var-file=tfvars/us-east1-b-sandbox.tfvars
       opentofu_state_bucket: plt-k8s-0bf7-sb
       opentofu_version: ${{ vars.OPENTOFU_VERSION }}
@@ -107,20 +108,20 @@ jobs:
       working_directory: regional/datadog
       workload_identity_provider: projects/746490462722/locations/global/workloadIdentityPools/github-actions/providers/github-actions-oidc
     secrets:
-      gpg_passphrase: ${{ secrets.GPG_PASSPHRASE }}
       opentofu_plan_secret_args: >-
         -var=datadog_api_key=${{ secrets.DATADOG_API_KEY }}
         -var=datadog_app_key=${{ secrets.DATADOG_APP_KEY }}
 
   us_east4_a_datadog:
     name: "Datadog: us-east4-a"
-    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@367d86eecaab18bb7fae7f5fa17fe7001df13f16
+    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@e3c59e43f2458550c7f13b6369fb6978b6f42c6e # v0.2.9
     if: github.actor != 'dependabot[bot]'
     needs: us_east4_a_datadog_manifests
     with:
       checkout_ref: ${{ github.ref }}
       github_environment: "Sandbox Datadog: us-east4-a"
       service_account: plt-k8s-github@plt-lz-backend-tf69-sb.iam.gserviceaccount.com
+      opentofu_kms_encryption_key: projects/plt-lz-backend-tf69-sb/locations/us/keyRings/state-encryption/cryptoKeys/default
       opentofu_plan_args: -destroy -var-file=tfvars/us-east4-a-sandbox.tfvars
       opentofu_state_bucket: plt-k8s-0bf7-sb
       opentofu_version: ${{ vars.OPENTOFU_VERSION }}
@@ -128,216 +129,203 @@ jobs:
       working_directory: regional/datadog
       workload_identity_provider: projects/746490462722/locations/global/workloadIdentityPools/github-actions/providers/github-actions-oidc
     secrets:
-      gpg_passphrase: ${{ secrets.GPG_PASSPHRASE }}
       opentofu_plan_secret_args: >-
         -var=datadog_api_key=${{ secrets.DATADOG_API_KEY }}
         -var=datadog_app_key=${{ secrets.DATADOG_APP_KEY }}
 
   us_east1_b_opa_gatekeeper:
     name: "OPA Gatekeeper: us-east1-b"
-    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@367d86eecaab18bb7fae7f5fa17fe7001df13f16
+    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@e3c59e43f2458550c7f13b6369fb6978b6f42c6e # v0.2.9
     if: github.actor != 'dependabot[bot]'
     with:
       checkout_ref: ${{ github.ref }}
       github_environment: "Sandbox OPA Gatekeeper: us-east1-b"
       service_account: plt-k8s-github@plt-lz-backend-tf69-sb.iam.gserviceaccount.com
+      opentofu_kms_encryption_key: projects/plt-lz-backend-tf69-sb/locations/us/keyRings/state-encryption/cryptoKeys/default
       opentofu_plan_args: -destroy -var-file=tfvars/us-east1-b-sandbox.tfvars
       opentofu_state_bucket: plt-k8s-0bf7-sb
       opentofu_version: ${{ vars.OPENTOFU_VERSION }}
       opentofu_workspace: us-east1-b-opa-gatekeeper-sandbox
       working_directory: regional/opa-gatekeeper
       workload_identity_provider: projects/746490462722/locations/global/workloadIdentityPools/github-actions/providers/github-actions-oidc
-    secrets:
-      gpg_passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
   us_east4_a_opa_gatekeeper:
     name: "OPA Gatekeeper: us-east4-a"
-    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@367d86eecaab18bb7fae7f5fa17fe7001df13f16
+    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@e3c59e43f2458550c7f13b6369fb6978b6f42c6e # v0.2.9
     if: github.actor != 'dependabot[bot]'
     with:
       checkout_ref: ${{ github.ref }}
       github_environment: "Sandbox OPA Gatekeeper: us-east4-a"
       service_account: plt-k8s-github@plt-lz-backend-tf69-sb.iam.gserviceaccount.com
+      opentofu_kms_encryption_key: projects/plt-lz-backend-tf69-sb/locations/us/keyRings/state-encryption/cryptoKeys/default
       opentofu_plan_args: -destroy -var-file=tfvars/us-east4-a-sandbox.tfvars
       opentofu_state_bucket: plt-k8s-0bf7-sb
       opentofu_version: ${{ vars.OPENTOFU_VERSION }}
       opentofu_workspace: us-east4-a-opa-gatekeeper-sandbox
       working_directory: regional/opa-gatekeeper
       workload_identity_provider: projects/746490462722/locations/global/workloadIdentityPools/github-actions/providers/github-actions-oidc
-    secrets:
-      gpg_passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
   us_east1_b_cert_manager:
     name: "cert-manager: us-east1-b"
-    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@367d86eecaab18bb7fae7f5fa17fe7001df13f16
+    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@e3c59e43f2458550c7f13b6369fb6978b6f42c6e # v0.2.9
     if: github.actor != 'dependabot[bot]'
     with:
       checkout_ref: ${{ github.ref }}
       github_environment: "Sandbox cert-manager: us-east1-b"
       service_account: plt-k8s-github@plt-lz-backend-tf69-sb.iam.gserviceaccount.com
+      opentofu_kms_encryption_key: projects/plt-lz-backend-tf69-sb/locations/us/keyRings/state-encryption/cryptoKeys/default
       opentofu_plan_args: -destroy -var-file=tfvars/us-east1-b-sandbox.tfvars
       opentofu_state_bucket: plt-k8s-0bf7-sb
       opentofu_version: ${{ vars.OPENTOFU_VERSION }}
       opentofu_workspace: us-east1-b-cert-manager-sandbox
       working_directory: regional/cert-manager
       workload_identity_provider: projects/746490462722/locations/global/workloadIdentityPools/github-actions/providers/github-actions-oidc
-    secrets:
-      gpg_passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
   us_east4_a_cert_manager:
     name: "cert-manager: us-east4-a"
-    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@367d86eecaab18bb7fae7f5fa17fe7001df13f16
+    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@e3c59e43f2458550c7f13b6369fb6978b6f42c6e # v0.2.9
     if: github.actor != 'dependabot[bot]'
     with:
       checkout_ref: ${{ github.ref }}
       github_environment: "Sandbox cert-manager: us-east4-a"
       service_account: plt-k8s-github@plt-lz-backend-tf69-sb.iam.gserviceaccount.com
+      opentofu_kms_encryption_key: projects/plt-lz-backend-tf69-sb/locations/us/keyRings/state-encryption/cryptoKeys/default
       opentofu_plan_args: -destroy -var-file=tfvars/us-east4-a-sandbox.tfvars
       opentofu_state_bucket: plt-k8s-0bf7-sb
       opentofu_version: ${{ vars.OPENTOFU_VERSION }}
       opentofu_workspace: us-east4-a-cert-manager-sandbox
       working_directory: regional/cert-manager
       workload_identity_provider: projects/746490462722/locations/global/workloadIdentityPools/github-actions/providers/github-actions-oidc
-    secrets:
-      gpg_passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
   us_east1_b_cert_manager_istio_csr:
     name: "cert-manager Istio CSR: us-east1-b"
-    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@367d86eecaab18bb7fae7f5fa17fe7001df13f16
+    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@e3c59e43f2458550c7f13b6369fb6978b6f42c6e # v0.2.9
     if: github.actor != 'dependabot[bot]'
     with:
       checkout_ref: ${{ github.ref }}
       github_environment: "Sandbox cert-manager Istio CSR: us-east1-b"
       service_account: plt-k8s-github@plt-lz-backend-tf69-sb.iam.gserviceaccount.com
+      opentofu_kms_encryption_key: projects/plt-lz-backend-tf69-sb/locations/us/keyRings/state-encryption/cryptoKeys/default
       opentofu_plan_args: -destroy -var-file=tfvars/us-east1-b-sandbox.tfvars
       opentofu_state_bucket: plt-k8s-0bf7-sb
       opentofu_version: ${{ vars.OPENTOFU_VERSION }}
       opentofu_workspace: us-east1-b-cert-manager-istio-csr-sandbox
       working_directory: regional/cert-manager/istio-csr
       workload_identity_provider: projects/746490462722/locations/global/workloadIdentityPools/github-actions/providers/github-actions-oidc
-    secrets:
-      gpg_passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
   us_east4_a_cert_manager_istio_csr:
     name: "cert-manager Istio CSR: us-east4-a"
-    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@367d86eecaab18bb7fae7f5fa17fe7001df13f16
+    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@e3c59e43f2458550c7f13b6369fb6978b6f42c6e # v0.2.9
     if: github.actor != 'dependabot[bot]'
     with:
       checkout_ref: ${{ github.ref }}
       github_environment: "Sandbox cert-manager Istio CSR: us-east4-a"
       service_account: plt-k8s-github@plt-lz-backend-tf69-sb.iam.gserviceaccount.com
+      opentofu_kms_encryption_key: projects/plt-lz-backend-tf69-sb/locations/us/keyRings/state-encryption/cryptoKeys/default
       opentofu_plan_args: -destroy -var-file=tfvars/us-east4-a-sandbox.tfvars
       opentofu_state_bucket: plt-k8s-0bf7-sb
       opentofu_version: ${{ vars.OPENTOFU_VERSION }}
       opentofu_workspace: us-east4-a-cert-manager-istio-csr-sandbox
       working_directory: regional/cert-manager/istio-csr
       workload_identity_provider: projects/746490462722/locations/global/workloadIdentityPools/github-actions/providers/github-actions-oidc
-    secrets:
-      gpg_passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
   us_east1_b_istio:
     name: "Istio: us-east1-b"
-    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@367d86eecaab18bb7fae7f5fa17fe7001df13f16
+    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@e3c59e43f2458550c7f13b6369fb6978b6f42c6e # v0.2.9
     needs: us_east1_b_istio_test
     if: github.actor != 'dependabot[bot]'
     with:
       checkout_ref: ${{ github.ref }}
       github_environment: "Sandbox Istio: us-east1-b"
       service_account: plt-k8s-github@plt-lz-backend-tf69-sb.iam.gserviceaccount.com
+      opentofu_kms_encryption_key: projects/plt-lz-backend-tf69-sb/locations/us/keyRings/state-encryption/cryptoKeys/default
       opentofu_plan_args: -destroy -var-file=tfvars/us-east1-b-sandbox.tfvars
       opentofu_state_bucket: plt-k8s-0bf7-sb
       opentofu_version: ${{ vars.OPENTOFU_VERSION }}
       opentofu_workspace: us-east1-b-istio-sandbox
       working_directory: regional/istio
       workload_identity_provider: projects/746490462722/locations/global/workloadIdentityPools/github-actions/providers/github-actions-oidc
-    secrets:
-      gpg_passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
   us_east4_a_istio:
     name: "Istio: us-east4-a"
-    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@367d86eecaab18bb7fae7f5fa17fe7001df13f16
+    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@e3c59e43f2458550c7f13b6369fb6978b6f42c6e # v0.2.9
     if: github.actor != 'dependabot[bot]'
     with:
       checkout_ref: ${{ github.ref }}
       github_environment: "Sandbox Istio: us-east4-a"
       service_account: plt-k8s-github@plt-lz-backend-tf69-sb.iam.gserviceaccount.com
+      opentofu_kms_encryption_key: projects/plt-lz-backend-tf69-sb/locations/us/keyRings/state-encryption/cryptoKeys/default
       opentofu_plan_args: -destroy -var-file=tfvars/us-east4-a-sandbox.tfvars
       opentofu_state_bucket: plt-k8s-0bf7-sb
       opentofu_version: ${{ vars.OPENTOFU_VERSION }}
       opentofu_workspace: us-east4-a-istio-sandbox
       working_directory: regional/istio
       workload_identity_provider: projects/746490462722/locations/global/workloadIdentityPools/github-actions/providers/github-actions-oidc
-    secrets:
-      gpg_passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
   us_east1_b_onboarding:
     name: "Onboarding: us-east1-b"
-    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@367d86eecaab18bb7fae7f5fa17fe7001df13f16
+    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@e3c59e43f2458550c7f13b6369fb6978b6f42c6e # v0.2.9
     if: github.actor != 'dependabot[bot]'
     needs: [us_east1_b_datadog, us_east1_b_cert_manager, us_east1_b_cert_manager_istio_csr, us_east1_b_istio]
     with:
       checkout_ref: ${{ github.ref }}
       github_environment: "Sandbox Onboarding: us-east1-b"
       service_account: plt-k8s-github@plt-lz-backend-tf69-sb.iam.gserviceaccount.com
+      opentofu_kms_encryption_key: projects/plt-lz-backend-tf69-sb/locations/us/keyRings/state-encryption/cryptoKeys/default
       opentofu_plan_args: -destroy -var-file=tfvars/us-east1-b-sandbox.tfvars -var-file=../../shared/tfvars/sandbox.tfvars
       opentofu_state_bucket: plt-k8s-0bf7-sb
       opentofu_version: ${{ vars.OPENTOFU_VERSION }}
       opentofu_workspace: us-east1-b-onboarding-sandbox
       working_directory: regional/onboarding
       workload_identity_provider: projects/746490462722/locations/global/workloadIdentityPools/github-actions/providers/github-actions-oidc
-    secrets:
-      gpg_passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
   us_east4_a_onboarding:
     name: "Onboarding: us-east4-a"
-    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@367d86eecaab18bb7fae7f5fa17fe7001df13f16
+    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@e3c59e43f2458550c7f13b6369fb6978b6f42c6e # v0.2.9
     if: github.actor != 'dependabot[bot]'
     needs: [us_east4_a_datadog, us_east4_a_cert_manager, us_east4_a_cert_manager_istio_csr, us_east4_a_istio]
     with:
       checkout_ref: ${{ github.ref }}
       github_environment: "Sandbox Onboarding: us-east4-a"
       service_account: plt-k8s-github@plt-lz-backend-tf69-sb.iam.gserviceaccount.com
+      opentofu_kms_encryption_key: projects/plt-lz-backend-tf69-sb/locations/us/keyRings/state-encryption/cryptoKeys/default
       opentofu_plan_args: -destroy -var-file=tfvars/us-east4-a-sandbox.tfvars -var-file=../../shared/tfvars/sandbox.tfvars
       opentofu_state_bucket: plt-k8s-0bf7-sb
       opentofu_version: ${{ vars.OPENTOFU_VERSION }}
       opentofu_workspace: us-east4-a-onboarding-sandbox
       working_directory: regional/onboarding
       workload_identity_provider: projects/746490462722/locations/global/workloadIdentityPools/github-actions/providers/github-actions-oidc
-    secrets:
-      gpg_passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
   us_east1_b:
     name: "Regional: us-east1-b"
-    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@367d86eecaab18bb7fae7f5fa17fe7001df13f16
+    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@e3c59e43f2458550c7f13b6369fb6978b6f42c6e # v0.2.9
     if: github.actor != 'dependabot[bot]'
     needs: us_east1_b_onboarding
     with:
       checkout_ref: ${{ github.ref }}
       github_environment: "Sandbox: us-east1-b"
       service_account: plt-k8s-github@plt-lz-backend-tf69-sb.iam.gserviceaccount.com
+      opentofu_kms_encryption_key: projects/plt-lz-backend-tf69-sb/locations/us/keyRings/state-encryption/cryptoKeys/default
       opentofu_plan_args: -destroy -var-file=tfvars/us-east1-b-sandbox.tfvars
       opentofu_state_bucket: plt-k8s-0bf7-sb
       opentofu_version: ${{ vars.OPENTOFU_VERSION }}
       opentofu_workspace: us-east1-b-sandbox
       working_directory: regional
       workload_identity_provider: projects/746490462722/locations/global/workloadIdentityPools/github-actions/providers/github-actions-oidc
-    secrets:
-      gpg_passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
   us_east4_a:
     name: "Regional: us-east4-a"
-    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@367d86eecaab18bb7fae7f5fa17fe7001df13f16
+    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@e3c59e43f2458550c7f13b6369fb6978b6f42c6e # v0.2.9
     if: github.actor != 'dependabot[bot]'
     needs: us_east4_a_onboarding
     with:
       checkout_ref: ${{ github.ref }}
       github_environment: "Sandbox: us-east4-a"
       service_account: plt-k8s-github@plt-lz-backend-tf69-sb.iam.gserviceaccount.com
+      opentofu_kms_encryption_key: projects/plt-lz-backend-tf69-sb/locations/us/keyRings/state-encryption/cryptoKeys/default
       opentofu_plan_args: -destroy -var-file=tfvars/us-east4-a-sandbox.tfvars
       opentofu_state_bucket: plt-k8s-0bf7-sb
       opentofu_version: ${{ vars.OPENTOFU_VERSION }}
       opentofu_workspace: us-east4-a-sandbox
       working_directory: regional
       workload_identity_provider: projects/746490462722/locations/global/workloadIdentityPools/github-actions/providers/github-actions-oidc
-    secrets:
-      gpg_passphrase: ${{ secrets.GPG_PASSPHRASE }}

--- a/.github/workflows/sandbox.yml
+++ b/.github/workflows/sandbox.yml
@@ -19,284 +19,271 @@ permissions:
 jobs:
   main:
     name: "Main"
-    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@367d86eecaab18bb7fae7f5fa17fe7001df13f16
+    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@e3c59e43f2458550c7f13b6369fb6978b6f42c6e # v0.2.9
     if: github.actor != 'dependabot[bot]'
     with:
       checkout_ref: ${{ github.ref }}
       github_environment: "Sandbox: Main"
       service_account: plt-k8s-github@plt-lz-backend-tf69-sb.iam.gserviceaccount.com
+      opentofu_kms_encryption_key: projects/plt-lz-backend-tf69-sb/locations/us/keyRings/state-encryption/cryptoKeys/default
       opentofu_plan_args: -var-file=tfvars/sandbox.tfvars -var-file=shared/tfvars/sandbox.tfvars
       opentofu_state_bucket: plt-k8s-0bf7-sb
       opentofu_version: ${{ vars.OPENTOFU_VERSION }}
       opentofu_workspace: main-sandbox
       workload_identity_provider: projects/746490462722/locations/global/workloadIdentityPools/github-actions/providers/github-actions-oidc
     secrets:
-      gpg_passphrase: ${{ secrets.GPG_PASSPHRASE }}
       opentofu_plan_secret_args: >-
         -var=datadog_api_key=${{ secrets.DATADOG_API_KEY }}
         -var=datadog_app_key=${{ secrets.DATADOG_APP_KEY }}
 
   us_east1_b:
     name: "Regional: us-east1-b"
-    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@367d86eecaab18bb7fae7f5fa17fe7001df13f16
+    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@e3c59e43f2458550c7f13b6369fb6978b6f42c6e # v0.2.9
     if: github.actor != 'dependabot[bot]'
     needs: main
     with:
       checkout_ref: ${{ github.ref }}
       github_environment: "Sandbox: us-east1-b"
       service_account: plt-k8s-github@plt-lz-backend-tf69-sb.iam.gserviceaccount.com
+      opentofu_kms_encryption_key: projects/plt-lz-backend-tf69-sb/locations/us/keyRings/state-encryption/cryptoKeys/default
       opentofu_plan_args: -var-file=tfvars/us-east1-b-sandbox.tfvars
       opentofu_state_bucket: plt-k8s-0bf7-sb
       opentofu_version: ${{ vars.OPENTOFU_VERSION }}
       opentofu_workspace: us-east1-b-sandbox
       working_directory: regional
       workload_identity_provider: projects/746490462722/locations/global/workloadIdentityPools/github-actions/providers/github-actions-oidc
-    secrets:
-      gpg_passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
   us_east4_a:
     name: "Regional: us-east4-a"
-    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@367d86eecaab18bb7fae7f5fa17fe7001df13f16
+    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@e3c59e43f2458550c7f13b6369fb6978b6f42c6e # v0.2.9
     if: github.actor != 'dependabot[bot]'
     needs: main
     with:
       checkout_ref: ${{ github.ref }}
       github_environment: "Sandbox: us-east4-a"
       service_account: plt-k8s-github@plt-lz-backend-tf69-sb.iam.gserviceaccount.com
+      opentofu_kms_encryption_key: projects/plt-lz-backend-tf69-sb/locations/us/keyRings/state-encryption/cryptoKeys/default
       opentofu_plan_args: -var-file=tfvars/us-east4-a-sandbox.tfvars
       opentofu_state_bucket: plt-k8s-0bf7-sb
       opentofu_version: ${{ vars.OPENTOFU_VERSION }}
       opentofu_workspace: us-east4-a-sandbox
       working_directory: regional
       workload_identity_provider: projects/746490462722/locations/global/workloadIdentityPools/github-actions/providers/github-actions-oidc
-    secrets:
-      gpg_passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
   us_east1_b_onboarding:
     name: "Onboarding: us-east1-b"
-    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@367d86eecaab18bb7fae7f5fa17fe7001df13f16
+    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@e3c59e43f2458550c7f13b6369fb6978b6f42c6e # v0.2.9
     if: github.actor != 'dependabot[bot]'
     needs: us_east1_b
     with:
       checkout_ref: ${{ github.ref }}
       github_environment: "Sandbox Onboarding: us-east1-b"
       service_account: plt-k8s-github@plt-lz-backend-tf69-sb.iam.gserviceaccount.com
+      opentofu_kms_encryption_key: projects/plt-lz-backend-tf69-sb/locations/us/keyRings/state-encryption/cryptoKeys/default
       opentofu_plan_args: -var-file=tfvars/us-east1-b-sandbox.tfvars -var-file=../../shared/tfvars/sandbox.tfvars
       opentofu_state_bucket: plt-k8s-0bf7-sb
       opentofu_version: ${{ vars.OPENTOFU_VERSION }}
       opentofu_workspace: us-east1-b-onboarding-sandbox
       working_directory: regional/onboarding
       workload_identity_provider: projects/746490462722/locations/global/workloadIdentityPools/github-actions/providers/github-actions-oidc
-    secrets:
-      gpg_passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
   us_east4_a_onboarding:
     name: "Onboarding: us-east4-a"
-    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@367d86eecaab18bb7fae7f5fa17fe7001df13f16
+    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@e3c59e43f2458550c7f13b6369fb6978b6f42c6e # v0.2.9
     if: github.actor != 'dependabot[bot]'
     needs: us_east4_a
     with:
       checkout_ref: ${{ github.ref }}
       github_environment: "Sandbox Onboarding: us-east4-a"
       service_account: plt-k8s-github@plt-lz-backend-tf69-sb.iam.gserviceaccount.com
+      opentofu_kms_encryption_key: projects/plt-lz-backend-tf69-sb/locations/us/keyRings/state-encryption/cryptoKeys/default
       opentofu_plan_args: -var-file=tfvars/us-east4-a-sandbox.tfvars -var-file=../../shared/tfvars/sandbox.tfvars
       opentofu_state_bucket: plt-k8s-0bf7-sb
       opentofu_version: ${{ vars.OPENTOFU_VERSION }}
       opentofu_workspace: us-east4-a-onboarding-sandbox
       working_directory: regional/onboarding
       workload_identity_provider: projects/746490462722/locations/global/workloadIdentityPools/github-actions/providers/github-actions-oidc
-    secrets:
-      gpg_passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
   us_east1_b_opa_gatekeeper:
     name: "OPA Gatekeeper: us-east1-b"
-    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@367d86eecaab18bb7fae7f5fa17fe7001df13f16
+    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@e3c59e43f2458550c7f13b6369fb6978b6f42c6e # v0.2.9
     if: github.actor != 'dependabot[bot]'
     needs: us_east1_b_cert_manager
     with:
       checkout_ref: ${{ github.ref }}
       github_environment: "Sandbox OPA Gatekeeper: us-east1-b"
       service_account: plt-k8s-github@plt-lz-backend-tf69-sb.iam.gserviceaccount.com
+      opentofu_kms_encryption_key: projects/plt-lz-backend-tf69-sb/locations/us/keyRings/state-encryption/cryptoKeys/default
       opentofu_plan_args: -var-file=tfvars/us-east1-b-sandbox.tfvars
       opentofu_state_bucket: plt-k8s-0bf7-sb
       opentofu_version: ${{ vars.OPENTOFU_VERSION }}
       opentofu_workspace: us-east1-b-opa-gatekeeper-sandbox
       working_directory: regional/opa-gatekeeper
       workload_identity_provider: projects/746490462722/locations/global/workloadIdentityPools/github-actions/providers/github-actions-oidc
-    secrets:
-      gpg_passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
   us_east4_a_opa_gatekeeper:
     name: "OPA Gatekeeper: us-east4-a"
-    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@367d86eecaab18bb7fae7f5fa17fe7001df13f16
+    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@e3c59e43f2458550c7f13b6369fb6978b6f42c6e # v0.2.9
     if: github.actor != 'dependabot[bot]'
     needs: us_east4_a_cert_manager
     with:
       checkout_ref: ${{ github.ref }}
       github_environment: "Sandbox OPA Gatekeeper: us-east4-a"
       service_account: plt-k8s-github@plt-lz-backend-tf69-sb.iam.gserviceaccount.com
+      opentofu_kms_encryption_key: projects/plt-lz-backend-tf69-sb/locations/us/keyRings/state-encryption/cryptoKeys/default
       opentofu_plan_args: -var-file=tfvars/us-east4-a-sandbox.tfvars
       opentofu_state_bucket: plt-k8s-0bf7-sb
       opentofu_version: ${{ vars.OPENTOFU_VERSION }}
       opentofu_workspace: us-east4-a-opa-gatekeeper-sandbox
       working_directory: regional/opa-gatekeeper
       workload_identity_provider: projects/746490462722/locations/global/workloadIdentityPools/github-actions/providers/github-actions-oidc
-    secrets:
-      gpg_passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
   us_east1_b_cert_manager:
     name: "cert-manager: us-east1-b"
-    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@367d86eecaab18bb7fae7f5fa17fe7001df13f16
+    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@e3c59e43f2458550c7f13b6369fb6978b6f42c6e # v0.2.9
     if: github.actor != 'dependabot[bot]'
     needs: us_east1_b_onboarding
     with:
       checkout_ref: ${{ github.ref }}
       github_environment: "Sandbox cert-manager: us-east1-b"
       service_account: plt-k8s-github@plt-lz-backend-tf69-sb.iam.gserviceaccount.com
+      opentofu_kms_encryption_key: projects/plt-lz-backend-tf69-sb/locations/us/keyRings/state-encryption/cryptoKeys/default
       opentofu_plan_args: -var-file=tfvars/us-east1-b-sandbox.tfvars
       opentofu_state_bucket: plt-k8s-0bf7-sb
       opentofu_version: ${{ vars.OPENTOFU_VERSION }}
       opentofu_workspace: us-east1-b-cert-manager-sandbox
       working_directory: regional/cert-manager
       workload_identity_provider: projects/746490462722/locations/global/workloadIdentityPools/github-actions/providers/github-actions-oidc
-    secrets:
-      gpg_passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
   us_east4_a_cert_manager:
     name: "cert-manager: us-east4-a"
-    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@367d86eecaab18bb7fae7f5fa17fe7001df13f16
+    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@e3c59e43f2458550c7f13b6369fb6978b6f42c6e # v0.2.9
     if: github.actor != 'dependabot[bot]'
     needs: us_east4_a_onboarding
     with:
       checkout_ref: ${{ github.ref }}
       github_environment: "Sandbox cert-manager: us-east4-a"
       service_account: plt-k8s-github@plt-lz-backend-tf69-sb.iam.gserviceaccount.com
+      opentofu_kms_encryption_key: projects/plt-lz-backend-tf69-sb/locations/us/keyRings/state-encryption/cryptoKeys/default
       opentofu_plan_args: -var-file=tfvars/us-east4-a-sandbox.tfvars
       opentofu_state_bucket: plt-k8s-0bf7-sb
       opentofu_version: ${{ vars.OPENTOFU_VERSION }}
       opentofu_workspace: us-east4-a-cert-manager-sandbox
       working_directory: regional/cert-manager
       workload_identity_provider: projects/746490462722/locations/global/workloadIdentityPools/github-actions/providers/github-actions-oidc
-    secrets:
-      gpg_passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
   us_east1_b_cert_manager_istio_csr:
     name: "cert-manager Istio CSR: us-east1-b"
-    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@367d86eecaab18bb7fae7f5fa17fe7001df13f16
+    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@e3c59e43f2458550c7f13b6369fb6978b6f42c6e # v0.2.9
     if: github.actor != 'dependabot[bot]'
     needs: us_east1_b_cert_manager
     with:
       checkout_ref: ${{ github.ref }}
       github_environment: "Sandbox cert-manager Istio CSR: us-east1-b"
       service_account: plt-k8s-github@plt-lz-backend-tf69-sb.iam.gserviceaccount.com
+      opentofu_kms_encryption_key: projects/plt-lz-backend-tf69-sb/locations/us/keyRings/state-encryption/cryptoKeys/default
       opentofu_plan_args: -var-file=tfvars/us-east1-b-sandbox.tfvars
       opentofu_state_bucket: plt-k8s-0bf7-sb
       opentofu_version: ${{ vars.OPENTOFU_VERSION }}
       opentofu_workspace: us-east1-b-cert-manager-istio-csr-sandbox
       working_directory: regional/cert-manager/istio-csr
       workload_identity_provider: projects/746490462722/locations/global/workloadIdentityPools/github-actions/providers/github-actions-oidc
-    secrets:
-      gpg_passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
   us_east4_a_cert_manager_istio_csr:
     name: "cert-manager Istio CSR: us-east4-a"
-    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@367d86eecaab18bb7fae7f5fa17fe7001df13f16
+    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@e3c59e43f2458550c7f13b6369fb6978b6f42c6e # v0.2.9
     if: github.actor != 'dependabot[bot]'
     needs: us_east4_a_cert_manager
     with:
       checkout_ref: ${{ github.ref }}
       github_environment: "Sandbox cert-manager Istio CSR: us-east4-a"
       service_account: plt-k8s-github@plt-lz-backend-tf69-sb.iam.gserviceaccount.com
+      opentofu_kms_encryption_key: projects/plt-lz-backend-tf69-sb/locations/us/keyRings/state-encryption/cryptoKeys/default
       opentofu_plan_args: -var-file=tfvars/us-east4-a-sandbox.tfvars
       opentofu_state_bucket: plt-k8s-0bf7-sb
       opentofu_version: ${{ vars.OPENTOFU_VERSION }}
       opentofu_workspace: us-east4-a-cert-manager-istio-csr-sandbox
       working_directory: regional/cert-manager/istio-csr
       workload_identity_provider: projects/746490462722/locations/global/workloadIdentityPools/github-actions/providers/github-actions-oidc
-    secrets:
-      gpg_passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
   us_east1_b_istio:
     name: "Istio: us-east1-b"
-    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@367d86eecaab18bb7fae7f5fa17fe7001df13f16
+    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@e3c59e43f2458550c7f13b6369fb6978b6f42c6e # v0.2.9
     if: github.actor != 'dependabot[bot]'
     needs: us_east1_b_cert_manager_istio_csr
     with:
       checkout_ref: ${{ github.ref }}
       github_environment: "Sandbox Istio: us-east1-b"
       service_account: plt-k8s-github@plt-lz-backend-tf69-sb.iam.gserviceaccount.com
+      opentofu_kms_encryption_key: projects/plt-lz-backend-tf69-sb/locations/us/keyRings/state-encryption/cryptoKeys/default
       opentofu_plan_args: -var-file=tfvars/us-east1-b-sandbox.tfvars
       opentofu_state_bucket: plt-k8s-0bf7-sb
       opentofu_version: ${{ vars.OPENTOFU_VERSION }}
       opentofu_workspace: us-east1-b-istio-sandbox
       working_directory: regional/istio
       workload_identity_provider: projects/746490462722/locations/global/workloadIdentityPools/github-actions/providers/github-actions-oidc
-    secrets:
-      gpg_passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
   us_east4_a_istio:
     name: "Istio: us-east4-a"
-    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@367d86eecaab18bb7fae7f5fa17fe7001df13f16
+    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@e3c59e43f2458550c7f13b6369fb6978b6f42c6e # v0.2.9
     if: github.actor != 'dependabot[bot]'
     needs: us_east4_a_cert_manager_istio_csr
     with:
       checkout_ref: ${{ github.ref }}
       github_environment: "Sandbox Istio: us-east4-a"
       service_account: plt-k8s-github@plt-lz-backend-tf69-sb.iam.gserviceaccount.com
+      opentofu_kms_encryption_key: projects/plt-lz-backend-tf69-sb/locations/us/keyRings/state-encryption/cryptoKeys/default
       opentofu_plan_args: -var-file=tfvars/us-east4-a-sandbox.tfvars
       opentofu_state_bucket: plt-k8s-0bf7-sb
       opentofu_version: ${{ vars.OPENTOFU_VERSION }}
       opentofu_workspace: us-east4-a-istio-sandbox
       working_directory: regional/istio
       workload_identity_provider: projects/746490462722/locations/global/workloadIdentityPools/github-actions/providers/github-actions-oidc
-    secrets:
-      gpg_passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
   us_east1_b_istio_manifests:
     name: "Istio Manifests: us-east1-b"
-    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@367d86eecaab18bb7fae7f5fa17fe7001df13f16
+    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@e3c59e43f2458550c7f13b6369fb6978b6f42c6e # v0.2.9
     if: github.actor != 'dependabot[bot]'
     needs: us_east1_b_istio
     with:
       checkout_ref: ${{ github.ref }}
       github_environment: "Sandbox Istio Manifests: us-east1-b"
       service_account: plt-k8s-github@plt-lz-backend-tf69-sb.iam.gserviceaccount.com
+      opentofu_kms_encryption_key: projects/plt-lz-backend-tf69-sb/locations/us/keyRings/state-encryption/cryptoKeys/default
       opentofu_plan_args: -var-file=tfvars/us-east1-b-sandbox.tfvars
       opentofu_state_bucket: plt-k8s-0bf7-sb
       opentofu_version: ${{ vars.OPENTOFU_VERSION }}
       opentofu_workspace: us-east1-b-istio-manifests-sandbox
       working_directory: regional/istio/manifests
       workload_identity_provider: projects/746490462722/locations/global/workloadIdentityPools/github-actions/providers/github-actions-oidc
-    secrets:
-      gpg_passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
   us_east4_a_istio_manifests:
     name: "Istio Manifests: us-east4-a"
-    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@367d86eecaab18bb7fae7f5fa17fe7001df13f16
+    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@e3c59e43f2458550c7f13b6369fb6978b6f42c6e # v0.2.9
     if: github.actor != 'dependabot[bot]'
     needs: us_east4_a_istio
     with:
       checkout_ref: ${{ github.ref }}
       github_environment: "Sandbox Istio Manifests: us-east4-a"
       service_account: plt-k8s-github@plt-lz-backend-tf69-sb.iam.gserviceaccount.com
+      opentofu_kms_encryption_key: projects/plt-lz-backend-tf69-sb/locations/us/keyRings/state-encryption/cryptoKeys/default
       opentofu_plan_args: -var-file=tfvars/us-east4-a-sandbox.tfvars
       opentofu_state_bucket: plt-k8s-0bf7-sb
       opentofu_version: ${{ vars.OPENTOFU_VERSION }}
       opentofu_workspace: us-east4-a-istio-manifests-sandbox
       working_directory: regional/istio/manifests
       workload_identity_provider: projects/746490462722/locations/global/workloadIdentityPools/github-actions/providers/github-actions-oidc
-    secrets:
-      gpg_passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
   us_east1_b_istio_test:
     name: "Istio Test: us-east1-b"
-    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@367d86eecaab18bb7fae7f5fa17fe7001df13f16
+    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@e3c59e43f2458550c7f13b6369fb6978b6f42c6e # v0.2.9
     if: github.actor != 'dependabot[bot]'
     needs: us_east1_b_istio_manifests
     with:
       checkout_ref: ${{ github.ref }}
       github_environment: "Sandbox Istio Test: us-east1-b"
       service_account: plt-k8s-github@plt-lz-backend-tf69-sb.iam.gserviceaccount.com
+      opentofu_kms_encryption_key: projects/plt-lz-backend-tf69-sb/locations/us/keyRings/state-encryption/cryptoKeys/default
       opentofu_plan_args: -var-file=tfvars/us-east1-b-sandbox.tfvars
       opentofu_state_bucket: plt-k8s-0bf7-sb
       opentofu_version: ${{ vars.OPENTOFU_VERSION }}
@@ -304,20 +291,20 @@ jobs:
       working_directory: regional/istio/test
       workload_identity_provider: projects/746490462722/locations/global/workloadIdentityPools/github-actions/providers/github-actions-oidc
     secrets:
-      gpg_passphrase: ${{ secrets.GPG_PASSPHRASE }}
       opentofu_plan_secret_args: >-
         -var=datadog_api_key=${{ secrets.DATADOG_API_KEY }}
         -var=datadog_app_key=${{ secrets.DATADOG_APP_KEY }}
 
   us_east4_a_istio_test:
     name: "Istio Test: us-east4-a"
-    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@367d86eecaab18bb7fae7f5fa17fe7001df13f16
+    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@e3c59e43f2458550c7f13b6369fb6978b6f42c6e # v0.2.9
     if: github.actor != 'dependabot[bot]'
     needs: us_east4_a_istio_manifests
     with:
       checkout_ref: ${{ github.ref }}
       github_environment: "Sandbox Istio Test: us-east4-a"
       service_account: plt-k8s-github@plt-lz-backend-tf69-sb.iam.gserviceaccount.com
+      opentofu_kms_encryption_key: projects/plt-lz-backend-tf69-sb/locations/us/keyRings/state-encryption/cryptoKeys/default
       opentofu_plan_args: -var-file=tfvars/us-east4-a-sandbox.tfvars
       opentofu_state_bucket: plt-k8s-0bf7-sb
       opentofu_version: ${{ vars.OPENTOFU_VERSION }}
@@ -325,20 +312,20 @@ jobs:
       working_directory: regional/istio/test
       workload_identity_provider: projects/746490462722/locations/global/workloadIdentityPools/github-actions/providers/github-actions-oidc
     secrets:
-      gpg_passphrase: ${{ secrets.GPG_PASSPHRASE }}
       opentofu_plan_secret_args: >-
         -var=datadog_api_key=${{ secrets.DATADOG_API_KEY }}
         -var=datadog_app_key=${{ secrets.DATADOG_APP_KEY }}
 
   us_east1_b_datadog:
     name: "Datadog: us-east1-b"
-    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@367d86eecaab18bb7fae7f5fa17fe7001df13f16
+    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@e3c59e43f2458550c7f13b6369fb6978b6f42c6e # v0.2.9
     if: github.actor != 'dependabot[bot]'
     needs: us_east1_b_onboarding
     with:
       checkout_ref: ${{ github.ref }}
       github_environment: "Sandbox Datadog: us-east1-b"
       service_account: plt-k8s-github@plt-lz-backend-tf69-sb.iam.gserviceaccount.com
+      opentofu_kms_encryption_key: projects/plt-lz-backend-tf69-sb/locations/us/keyRings/state-encryption/cryptoKeys/default
       opentofu_plan_args: -var-file=tfvars/us-east1-b-sandbox.tfvars
       opentofu_state_bucket: plt-k8s-0bf7-sb
       opentofu_version: ${{ vars.OPENTOFU_VERSION }}
@@ -346,20 +333,20 @@ jobs:
       working_directory: regional/datadog
       workload_identity_provider: projects/746490462722/locations/global/workloadIdentityPools/github-actions/providers/github-actions-oidc
     secrets:
-      gpg_passphrase: ${{ secrets.GPG_PASSPHRASE }}
       opentofu_plan_secret_args: >-
         -var=datadog_api_key=${{ secrets.DATADOG_API_KEY }}
         -var=datadog_app_key=${{ secrets.DATADOG_APP_KEY }}
 
   us_east4_a_datadog:
     name: "Datadog: us-east4-a"
-    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@367d86eecaab18bb7fae7f5fa17fe7001df13f16
+    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@e3c59e43f2458550c7f13b6369fb6978b6f42c6e # v0.2.9
     if: github.actor != 'dependabot[bot]'
     needs: us_east4_a_onboarding
     with:
       checkout_ref: ${{ github.ref }}
       github_environment: "Sandbox Datadog: us-east4-a"
       service_account: plt-k8s-github@plt-lz-backend-tf69-sb.iam.gserviceaccount.com
+      opentofu_kms_encryption_key: projects/plt-lz-backend-tf69-sb/locations/us/keyRings/state-encryption/cryptoKeys/default
       opentofu_plan_args: -var-file=tfvars/us-east4-a-sandbox.tfvars
       opentofu_state_bucket: plt-k8s-0bf7-sb
       opentofu_version: ${{ vars.OPENTOFU_VERSION }}
@@ -367,20 +354,20 @@ jobs:
       working_directory: regional/datadog
       workload_identity_provider: projects/746490462722/locations/global/workloadIdentityPools/github-actions/providers/github-actions-oidc
     secrets:
-      gpg_passphrase: ${{ secrets.GPG_PASSPHRASE }}
       opentofu_plan_secret_args: >-
         -var=datadog_api_key=${{ secrets.DATADOG_API_KEY }}
         -var=datadog_app_key=${{ secrets.DATADOG_APP_KEY }}
 
   us_east1_b_datadog_manifests:
     name: "Datadog Manifests: us-east1-b"
-    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@367d86eecaab18bb7fae7f5fa17fe7001df13f16
+    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@e3c59e43f2458550c7f13b6369fb6978b6f42c6e # v0.2.9
     if: github.actor != 'dependabot[bot]'
     needs: us_east1_b_datadog
     with:
       checkout_ref: ${{ github.ref }}
       github_environment: "Sandbox Datadog Manifests: us-east1-b"
       service_account: plt-k8s-github@plt-lz-backend-tf69-sb.iam.gserviceaccount.com
+      opentofu_kms_encryption_key: projects/plt-lz-backend-tf69-sb/locations/us/keyRings/state-encryption/cryptoKeys/default
       opentofu_plan_args: -var-file=tfvars/us-east1-b-sandbox.tfvars
       opentofu_state_bucket: plt-k8s-0bf7-sb
       opentofu_version: ${{ vars.OPENTOFU_VERSION }}
@@ -388,20 +375,20 @@ jobs:
       working_directory: regional/datadog/manifests
       workload_identity_provider: projects/746490462722/locations/global/workloadIdentityPools/github-actions/providers/github-actions-oidc
     secrets:
-      gpg_passphrase: ${{ secrets.GPG_PASSPHRASE }}
       opentofu_plan_secret_args: >-
         -var=datadog_api_key=${{ secrets.DATADOG_API_KEY }}
         -var=datadog_app_key=${{ secrets.DATADOG_APP_KEY }}
 
   us_east4_a_datadog_manifests:
     name: "Datadog Manifests: us-east4-a"
-    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@367d86eecaab18bb7fae7f5fa17fe7001df13f16
+    uses: osinfra-io/github-opentofu-gcp-called-workflows/.github/workflows/plan-and-apply.yml@e3c59e43f2458550c7f13b6369fb6978b6f42c6e # v0.2.9
     if: github.actor != 'dependabot[bot]'
     needs: us_east4_a_datadog
     with:
       checkout_ref: ${{ github.ref }}
       github_environment: "Sandbox Datadog Manifests: us-east4-a"
       service_account: plt-k8s-github@plt-lz-backend-tf69-sb.iam.gserviceaccount.com
+      opentofu_kms_encryption_key: projects/plt-lz-backend-tf69-sb/locations/us/keyRings/state-encryption/cryptoKeys/default
       opentofu_plan_args: -var-file=tfvars/us-east4-a-sandbox.tfvars
       opentofu_state_bucket: plt-k8s-0bf7-sb
       opentofu_version: ${{ vars.OPENTOFU_VERSION }}
@@ -409,7 +396,6 @@ jobs:
       working_directory: regional/datadog/manifests
       workload_identity_provider: projects/746490462722/locations/global/workloadIdentityPools/github-actions/providers/github-actions-oidc
     secrets:
-      gpg_passphrase: ${{ secrets.GPG_PASSPHRASE }}
       opentofu_plan_secret_args: >-
         -var=datadog_api_key=${{ secrets.DATADOG_API_KEY }}
         -var=datadog_app_key=${{ secrets.DATADOG_APP_KEY }}

--- a/providers.tofu
+++ b/providers.tofu
@@ -1,4 +1,40 @@
 terraform {
+  # State and Plan Encryption
+  # https://opentofu.org/docs/language/state/encryption
+
+  # The commented out sections below demonstrate how to configure
+  # fallback encryption methods for state and plan files for bootstrapping.
+
+  encryption {
+    method "unencrypted" "migrate" {}
+
+    key_provider "gcp_kms" "default" {
+      kms_encryption_key = var.state_kms_encryption_key
+      key_length         = 32
+    }
+
+    method "aes_gcm" "default" {
+      keys = key_provider.gcp_kms.default
+    }
+
+    plan {
+      method = method.aes_gcm.default
+      # enforced = true
+
+      fallback {
+        method = method.unencrypted.migrate
+      }
+    }
+
+    state {
+      method = method.aes_gcm.default
+      # enforced = true
+
+      fallback {
+        method = method.unencrypted.migrate
+      }
+    }
+  }
 
   # Requiring Providers
   # https://opentofu.org/docs/language/providers/requirements/

--- a/regional/cert-manager/istio-csr/providers.tofu
+++ b/regional/cert-manager/istio-csr/providers.tofu
@@ -1,0 +1,1 @@
+../../shared/providers.tofu

--- a/regional/cert-manager/istio-csr/variables.tofu
+++ b/regional/cert-manager/istio-csr/variables.tofu
@@ -5,3 +5,21 @@ variable "remote_bucket" {
   type        = string
   description = "The remote bucket the `terraform_remote_state` data source retrieves the state from"
 }
+
+# These three state_* variables are required for early variable evaluation for backend and provider configuration.
+# They are defined in the GitHub Actions called workflows and should NOT be set in the OpenTofu configuration.
+
+variable "state_bucket" {
+  description = "The name of the GCS bucket to store state files"
+  type        = string
+}
+
+variable "state_kms_encryption_key" {
+  description = "The KMS encryption key for state and plan files"
+  type        = string
+}
+
+variable "state_prefix" {
+  description = "The prefix for state files in the GCS bucket"
+  type        = string
+}

--- a/regional/cert-manager/variables.tofu
+++ b/regional/cert-manager/variables.tofu
@@ -1,16 +1,6 @@
 # Input Variables
 # https://opentofu.org/docs/language/values/variables
 
-variable "kubernetes_engine_namespaces" {
-  description = "Map of namespaces and service accounts to onboard to GKE"
-  type        = map(any)
-}
-
-variable "remote_bucket" {
-  type        = string
-  description = "The remote bucket the `terraform_remote_state` data source retrieves the state from"
-}
-
 # These three state_* variables are required for early variable evaluation for backend and provider configuration.
 # They are defined in the GitHub Actions called workflows and should NOT be set in the OpenTofu configuration.
 

--- a/regional/datadog/manifests/variables.tofu
+++ b/regional/datadog/manifests/variables.tofu
@@ -9,3 +9,21 @@ variable "datadog_app_key" {
   type        = string
   sensitive   = true
 }
+
+# These three state_* variables are required for early variable evaluation for backend and provider configuration.
+# They are defined in the GitHub Actions called workflows and should NOT be set in the OpenTofu configuration.
+
+variable "state_bucket" {
+  description = "The name of the GCS bucket to store state files"
+  type        = string
+}
+
+variable "state_kms_encryption_key" {
+  description = "The KMS encryption key for state and plan files"
+  type        = string
+}
+
+variable "state_prefix" {
+  description = "The prefix for state files in the GCS bucket"
+  type        = string
+}

--- a/regional/datadog/variables.tofu
+++ b/regional/datadog/variables.tofu
@@ -9,3 +9,21 @@ variable "datadog_app_key" {
   type        = string
   sensitive   = true
 }
+
+# These three state_* variables are required for early variable evaluation for backend and provider configuration.
+# They are defined in the GitHub Actions called workflows and should NOT be set in the OpenTofu configuration.
+
+variable "state_bucket" {
+  description = "The name of the GCS bucket to store state files"
+  type        = string
+}
+
+variable "state_kms_encryption_key" {
+  description = "The KMS encryption key for state and plan files"
+  type        = string
+}
+
+variable "state_prefix" {
+  description = "The prefix for state files in the GCS bucket"
+  type        = string
+}

--- a/regional/istio/manifests/variables.tofu
+++ b/regional/istio/manifests/variables.tofu
@@ -48,3 +48,21 @@ variable "kubernetes_istio_virtual_services" {
   }))
   default = {}
 }
+
+# These three state_* variables are required for early variable evaluation for backend and provider configuration.
+# They are defined in the GitHub Actions called workflows and should NOT be set in the OpenTofu configuration.
+
+variable "state_bucket" {
+  description = "The name of the GCS bucket to store state files"
+  type        = string
+}
+
+variable "state_kms_encryption_key" {
+  description = "The KMS encryption key for state and plan files"
+  type        = string
+}
+
+variable "state_prefix" {
+  description = "The prefix for state files in the GCS bucket"
+  type        = string
+}

--- a/regional/istio/test/variables.tofu
+++ b/regional/istio/test/variables.tofu
@@ -21,3 +21,21 @@ variable "istio_test_version" {
   type        = string
   default     = "v0.3.4"
 }
+
+# These three state_* variables are required for early variable evaluation for backend and provider configuration.
+# They are defined in the GitHub Actions called workflows and should NOT be set in the OpenTofu configuration.
+
+variable "state_bucket" {
+  description = "The name of the GCS bucket to store state files"
+  type        = string
+}
+
+variable "state_kms_encryption_key" {
+  description = "The KMS encryption key for state and plan files"
+  type        = string
+}
+
+variable "state_prefix" {
+  description = "The prefix for state files in the GCS bucket"
+  type        = string
+}

--- a/regional/istio/variables.tofu
+++ b/regional/istio/variables.tofu
@@ -98,3 +98,21 @@ variable "remote_bucket" {
   type        = string
   description = "The remote bucket the `terraform_remote_state` data source retrieves the state from"
 }
+
+# These three state_* variables are required for early variable evaluation for backend and provider configuration.
+# They are defined in the GitHub Actions called workflows and should NOT be set in the OpenTofu configuration.
+
+variable "state_bucket" {
+  description = "The name of the GCS bucket to store state files"
+  type        = string
+}
+
+variable "state_kms_encryption_key" {
+  description = "The KMS encryption key for state and plan files"
+  type        = string
+}
+
+variable "state_prefix" {
+  description = "The prefix for state files in the GCS bucket"
+  type        = string
+}

--- a/regional/opa-gatekeeper/variables.tofu
+++ b/regional/opa-gatekeeper/variables.tofu
@@ -1,16 +1,6 @@
 # Input Variables
 # https://opentofu.org/docs/language/values/variables
 
-variable "kubernetes_engine_namespaces" {
-  description = "Map of namespaces and service accounts to onboard to GKE"
-  type        = map(any)
-}
-
-variable "remote_bucket" {
-  type        = string
-  description = "The remote bucket the `terraform_remote_state` data source retrieves the state from"
-}
-
 # These three state_* variables are required for early variable evaluation for backend and provider configuration.
 # They are defined in the GitHub Actions called workflows and should NOT be set in the OpenTofu configuration.
 

--- a/regional/providers.tofu
+++ b/regional/providers.tofu
@@ -2,6 +2,43 @@
 # https://opentofu.org/docs/language/providers/requirements/
 
 terraform {
+  # State and Plan Encryption
+  # https://opentofu.org/docs/language/state/encryption
+
+  # The commented out sections below demonstrate how to configure
+  # fallback encryption methods for state and plan files for bootstrapping.
+
+  encryption {
+    method "unencrypted" "migrate" {}
+
+    key_provider "gcp_kms" "default" {
+      kms_encryption_key = var.state_kms_encryption_key
+      key_length         = 32
+    }
+
+    method "aes_gcm" "default" {
+      keys = key_provider.gcp_kms.default
+    }
+
+    plan {
+      method = method.aes_gcm.default
+      # enforced = true
+
+      fallback {
+        method = method.unencrypted.migrate
+      }
+    }
+
+    state {
+      method = method.aes_gcm.default
+      # enforced = true
+
+      fallback {
+        method = method.unencrypted.migrate
+      }
+    }
+  }
+
   required_providers {
 
     # Google Cloud Platform Provider

--- a/regional/shared/providers.tofu
+++ b/regional/shared/providers.tofu
@@ -2,6 +2,43 @@
 # https://opentofu.org/docs/language/providers/requirements/
 
 terraform {
+  # State and Plan Encryption
+  # https://opentofu.org/docs/language/state/encryption
+
+  # The commented out sections below demonstrate how to configure
+  # fallback encryption methods for state and plan files for bootstrapping.
+
+  encryption {
+    method "unencrypted" "migrate" {}
+
+    key_provider "gcp_kms" "default" {
+      kms_encryption_key = var.state_kms_encryption_key
+      key_length         = 32
+    }
+
+    method "aes_gcm" "default" {
+      keys = key_provider.gcp_kms.default
+    }
+
+    plan {
+      method = method.aes_gcm.default
+      # enforced = true
+
+      fallback {
+        method = method.unencrypted.migrate
+      }
+    }
+
+    state {
+      method = method.aes_gcm.default
+      # enforced = true
+
+      fallback {
+        method = method.unencrypted.migrate
+      }
+    }
+  }
+
   required_providers {
 
     # Google Cloud Platform Provider

--- a/regional/variables.tofu
+++ b/regional/variables.tofu
@@ -63,3 +63,21 @@ variable "remote_bucket" {
   type        = string
   description = "The remote bucket the `terraform_remote_state` data source retrieves the state from"
 }
+
+# These three state_* variables are required for early variable evaluation for backend and provider configuration.
+# They are defined in the GitHub Actions called workflows and should NOT be set in the OpenTofu configuration.
+
+variable "state_bucket" {
+  description = "The name of the GCS bucket to store state files"
+  type        = string
+}
+
+variable "state_kms_encryption_key" {
+  description = "The KMS encryption key for state and plan files"
+  type        = string
+}
+
+variable "state_prefix" {
+  description = "The prefix for state files in the GCS bucket"
+  type        = string
+}

--- a/shared/backend.tofu
+++ b/shared/backend.tofu
@@ -1,5 +1,13 @@
+# Backend Configuration
+# https://opentofu.org/docs/language/settings/backends/configuration
+
 terraform {
+  # Google Cloud Storage
+  # https://opentofu.org/docs/language/settings/backends/gcs
+
   backend "gcs" {
-    prefix = "google-cloud-kubernetes"
+    bucket             = var.state_bucket
+    kms_encryption_key = var.state_kms_encryption_key
+    prefix             = var.state_prefix
   }
 }

--- a/variables.tofu
+++ b/variables.tofu
@@ -64,3 +64,21 @@ variable "project_monthly_budget_amount" {
   type        = number
   default     = 5
 }
+
+# These three state_* variables are required for early variable evaluation for backend and provider configuration.
+# They are defined in the GitHub Actions called workflows and should NOT be set in the OpenTofu configuration.
+
+variable "state_bucket" {
+  description = "The name of the GCS bucket to store state files"
+  type        = string
+}
+
+variable "state_kms_encryption_key" {
+  description = "The KMS encryption key for state and plan files"
+  type        = string
+}
+
+variable "state_prefix" {
+  description = "The prefix for state files in the GCS bucket"
+  type        = string
+}


### PR DESCRIPTION
- Added encryption configuration to `providers.tofu` and `regional/providers.tofu` for state and plan files using GCP KMS and AES-GCM methods.
- Introduced variables for state management in multiple modules, including `state_bucket`, `state_kms_encryption_key`, and `state_prefix`.
- Updated backend configuration in `shared/backend.tofu` to utilize the new state management variables.
- Created new `providers.tofu` and `variables.tofu` files for `cert-manager` and `opa-gatekeeper` modules to support state management.